### PR TITLE
Make Makefile run with Podman

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,14 @@
 
 DOCKER_CMD ?= $(shell which docker 2> /dev/null || which podman 2> /dev/null || echo docker)
 
+ifneq (,$(findstring docker,$(DOCKER_CMD)))
+	DOCKER_SUDO = sudo -E
+endif
+
 .PHONY: lint
 lint:
-	sudo -E $(DOCKER_CMD) run --rm -v $$(pwd):/tmp/lint \
+	$(DOCKER_SUDO) $(DOCKER_CMD) run --rm -v $$(pwd):/tmp/lint \
 	-e RUN_LOCAL=true \
 	-e LINTER_RULES_PATH=/ \
 	-e VALIDATE_NATURAL_LANGUAGE=true \
-	github/super-linter
+	docker.io/github/super-linter


### PR DESCRIPTION
Podman requires the definition of DockerHub registry in front of the container name and it does not work with sudo.