### PR TITLE
fix: Webconsole guide's link

### DIFF
--- a/user-guide/exercises.md
+++ b/user-guide/exercises.md
@@ -834,7 +834,7 @@ You should now be able to navigate to
 [http://localhost:5000/](http://localhost:5000/) and access the free5gc WebUI.
 The test subscriber is the same as the standard free5gc default subscriber.
 Thus, you can follow the
-[instructions](https://free5gc.org/guide/New-Subscriber-via-webconsole/) on the
+[instructions](https://free5gc.org/guide/Webconsole/Create-Subscriber-via-webconsole/) on the
 free5gc site, but start at Step 4.
 
 Once the subscriber is registered, you can deploy UERANSIM:


### PR DESCRIPTION
Webconsole's guide has been updated and the url has been changed.
## Old
https://free5gc.org/guide/New-Subscriber-via-webconsole/
## New
https://free5gc.org/guide/Webconsole/Create-Subscriber-via-webconsole/