### PR TITLE
Common dependencies

### DIFF
--- a/content/en/docs/guides/install-guides/common-components.md
+++ b/content/en/docs/guides/install-guides/common-components.md
@@ -43,7 +43,7 @@ Nephio.
 To install the Nephio Operators, repeat the `kpt` steps, but for that package:
 
 ```bash
-kpt pkg get --for-deployment https://github.com/nephio-project/catalog/nephio/core/nephio-operator@main
+kpt pkg get --for-deployment https://github.com/nephio-project/catalog.git/nephio/core/nephio-operator@main
 kpt fn render nephio-operator
 kpt live init nephio-operator
 kpt live apply nephio-operator --reconcile-timeout=15m --output=table

--- a/content/en/docs/guides/install-guides/common-components.md
+++ b/content/en/docs/guides/install-guides/common-components.md
@@ -74,7 +74,7 @@ be installed via a package for convenience. This will install Repository
 resources pointing directly to the GitHub repositories, with read-only access.
 
 ```bash
-kpt pkg get --for-deployment https://github.com/nephio-project/catalog/nephio/optional/stock-repos@main
+kpt pkg get --for-deployment https://github.com/nephio-project/catalog.git/nephio/optional/stock-repos@main
 kpt fn render stock-repos
 kpt live init stock-repos
 kpt live apply stock-repos --reconcile-timeout=15m --output=table

--- a/content/en/docs/guides/install-guides/common-components.md
+++ b/content/en/docs/guides/install-guides/common-components.md
@@ -11,6 +11,9 @@ weight: 2
 This page is draft and the separation of the content to different categories is not clearly done. 
 {{% /pageinfo %}}
 
+> **_NOTE:_** If you want to use a version other than that at the tip of Nephio `catalog` repo, then replace the `@main` suffix on the package URLs on the `kpt pkg get` commands below with the tag of the version you wish to use.
+
+
 ### Porch
 
 This "Package Orchestration" component provides the Kubernetes APIs for
@@ -23,27 +26,27 @@ Fetch the package using `kpt`, and run any `kpt` functions, and then apply the
 package:
 
 ```bash
-kpt pkg get --for-deployment https://github.com/nephio-project/nephio-example-packages.git/porch-dev@v1.0.1
-kpt fn render porch-dev
-kpt live init porch-dev
-kpt live apply porch-dev --reconcile-timeout=15m --output=table
+kpt pkg get --for-deployment https://github.com/nephio-project/catalog/nephio/core/proch@main
+kpt fn render porch
+kpt live init porch
+kpt live apply porch --reconcile-timeout=15m --output=table
 ```
 
-### Nephio Controllers
+### Nephio Operators
 
-The Nephio Controllers provide implementations of the Nephio-specific APIs. This
+The Nephio Operators provide implementations of the Nephio-specific APIs. This
 includes the code that implements the various package specialization features -
 such as integration with IPAM and VLAN allocation, and NAD generation - as well
-as controllers that can provision repositories and bootstrap new clusters into
+as operators that can provision repositories and bootstrap new clusters into
 Nephio.
 
-To install the Nephio Controllers, repeat the `kpt` steps, but for that package:
+To install the Nephio Operators, repeat the `kpt` steps, but for that package:
 
 ```bash
-kpt pkg get --for-deployment https://github.com/nephio-project/nephio-example-packages.git/nephio-controllers@v1.0.1
-kpt fn render nephio-controllers
-kpt live init nephio-controllers
-kpt live apply nephio-controllers --reconcile-timeout=15m --output=table
+kpt pkg get --for-deployment https://github.com/nephio-project/catalog/nephio/core/nephio-operator@main
+kpt fn render nephio-operator
+kpt live init nephio-operator
+kpt live apply nephio-operator --reconcile-timeout=15m --output=table
 ```
 
 ### Management Cluster GitOps Tool
@@ -58,7 +61,7 @@ To install it on the management cluster, we again follow the same process.
 Later, we will configure it to point to the `mgmt` repository:
 
 ```bash
-kpt pkg get --for-deployment https://github.com/nephio-project/nephio-example-packages.git/configsync@v1.0.1
+kpt pkg get --for-deployment https://github.com/nephio-project/catalog/nephio/core/configsync@main
 kpt fn render configsync
 kpt live init configsync
 kpt live apply configsync --reconcile-timeout=15m --output=table
@@ -71,8 +74,8 @@ be installed via a package for convenience. This will install Repository
 resources pointing directly to the GitHub repositories, with read-only access.
 
 ```bash
-kpt pkg get --for-deployment https://github.com/nephio-project/nephio-example-packages.git/nephio-stock-repos@v1.0.1
-kpt fn render nephio-stock-repos
-kpt live init nephio-stock-repos
-kpt live apply nephio-stock-repos --reconcile-timeout=15m --output=table
+kpt pkg get --for-deployment https://github.com/nephio-project/catalog/nephio/optional/stock-repos@main
+kpt fn render stock-repos
+kpt live init stock-repos
+kpt live apply stock-repos --reconcile-timeout=15m --output=table
 ```

--- a/content/en/docs/guides/install-guides/common-components.md
+++ b/content/en/docs/guides/install-guides/common-components.md
@@ -61,7 +61,7 @@ To install it on the management cluster, we again follow the same process.
 Later, we will configure it to point to the `mgmt` repository:
 
 ```bash
-kpt pkg get --for-deployment https://github.com/nephio-project/catalog/nephio/core/configsync@main
+kpt pkg get --for-deployment https://github.com/nephio-project/catalog.git/nephio/core/configsync@main
 kpt fn render configsync
 kpt live init configsync
 kpt live apply configsync --reconcile-timeout=15m --output=table

--- a/content/en/docs/guides/install-guides/common-dependencies.md
+++ b/content/en/docs/guides/install-guides/common-dependencies.md
@@ -29,7 +29,7 @@ kpt live apply network-config --reconcile-timeout=15m --output=table
 The resource backend provides IP and VLAN allocation.
 
 ```bash
-kpt pkg get --for-deployment https://github.com/nephio-project/catalog/nephio/optional/resource-backend@main
+kpt pkg get --for-deployment https://github.com/nephio-project/catalog.git/nephio/optional/resource-backend@main
 kpt fn render resource-backend
 kpt live init resource-backend
 kpt live apply resource-backend --reconcile-timeout=15m --output=table

--- a/content/en/docs/guides/install-guides/common-dependencies.md
+++ b/content/en/docs/guides/install-guides/common-dependencies.md
@@ -18,7 +18,7 @@ This component is a controller for applying configuration to routers and
 switches.
 
 ```bash
-kpt pkg get --for-deployment https://github.com/nephio-project/catalog/nephio/optional/network-config@main
+kpt pkg get --for-deployment https://github.com/nephio-project/catalog.git/nephio/optional/network-config@main
 kpt fn render network-config
 kpt live init network-config
 kpt live apply network-config --reconcile-timeout=15m --output=table

--- a/content/en/docs/guides/install-guides/common-dependencies.md
+++ b/content/en/docs/guides/install-guides/common-dependencies.md
@@ -10,12 +10,12 @@ Some of these, like the resource-backend, will move out of the "required"
 category in later releases.  Even if you do not use these directly in your
 installation, the CRDs that come along with them are necessary.
 
+> **_NOTE:_** If you want to use a version other than that at the tip of Nephio `catalog` repo, then replace the `@main` suffix on the package URLs on the `kpt pkg get` commands below with the tag of the version you wish to use.
+
 ### Network Config Operator
 
 This component is a controller for applying configuration to routers and
 switches.
-
-> **_NOTE:_** If you want to use a version other than that at the tip of Nephio `catalog` repo, then replace the `@main` suffix on the package URLs on the `kpt pkg get` commands below with the tag of the version you wish to use.
 
 ```bash
 kpt pkg get --for-deployment https://github.com/nephio-project/catalog/nephio/optional/network-config@main

--- a/content/en/docs/guides/install-guides/common-dependencies.md
+++ b/content/en/docs/guides/install-guides/common-dependencies.md
@@ -15,8 +15,10 @@ installation, the CRDs that come along with them are necessary.
 This component is a controller for applying configuration to routers and
 switches.
 
+> **_NOTE:_** If you want to use a version other than that at the tip of Nephio `catalog` repo, then replace the `@main` suffix on the package URLs on the `kpt pkg get` commands below with the tag of the version you wish to use.
+
 ```bash
-kpt pkg get --for-deployment https://github.com/nephio-project/nephio-example-packages.git/network-config@v1.0.1
+kpt pkg get --for-deployment https://github.com/nephio-project/catalog/nephio/optional/network-config@main
 kpt fn render network-config
 kpt live init network-config
 kpt live apply network-config --reconcile-timeout=15m --output=table
@@ -27,7 +29,7 @@ kpt live apply network-config --reconcile-timeout=15m --output=table
 The resource backend provides IP and VLAN allocation.
 
 ```bash
-kpt pkg get --for-deployment https://github.com/nephio-project/nephio-example-packages.git/resource-backend@v1.0.1
+kpt pkg get --for-deployment https://github.com/nephio-project/catalog/nephio/optional/resource-backend@main
 kpt fn render resource-backend
 kpt live init resource-backend
 kpt live apply resource-backend --reconcile-timeout=15m --output=table

--- a/developer-guide/README.md
+++ b/developer-guide/README.md
@@ -1,7 +1,0 @@
-Nephio Developer Guide
-======================
-
-This developer guide is for for people who want to write code for the Nephio project. This document is written as an extension of the [Kubernetes Developer Guides](https://github.com/kubernetes/community/tree/master/contributors/devel#the-process-of-developing-and-contributing-code-to-the-kubernetes-project) and therefore covers topics that are specific to Nephio development.
-
-* How to set up a [Minimal Development Environment](minimal-environment.md) defines common terminology used in the Nephio project.
-* How to perform [Unit testing using mocking with Mockery](unit-testing-mockery.md).

--- a/developer-guide/README.md
+++ b/developer-guide/README.md
@@ -1,0 +1,7 @@
+Nephio Developer Guide
+======================
+
+This developer guide is for for people who want to write code for the Nephio project. This document is written as an extension of the [Kubernetes Developer Guides](https://github.com/kubernetes/community/tree/master/contributors/devel#the-process-of-developing-and-contributing-code-to-the-kubernetes-project) and therefore covers topics that are specific to Nephio development.
+
+* How to set up a [Minimal Development Environment](minimal-environment.md) defines common terminology used in the Nephio project.
+* How to perform [Unit testing using mocking with Mockery](unit-testing-mockery.md).


### PR DESCRIPTION
Update URLs for KPT packages to point at catalog packages and replaced the tag with `@main`, added a note to instruct people to replace the `@main`tag with whatever tag they want to pull