### PR TITLE
Revert inadvertent check in of file to documentation

### DIFF
--- a/developer-guide/README.md
+++ b/developer-guide/README.md
@@ -1,7 +1,0 @@
-Nephio Developer Guide
-======================
-
-This developer guide is for for people who want to write code for the Nephio project. This document is written as an extension of the [Kubernetes Developer Guides](https://github.com/kubernetes/community/tree/master/contributors/devel#the-process-of-developing-and-contributing-code-to-the-kubernetes-project) and therefore covers topics that are specific to Nephio development.
-
-* How to set up a [Minimal Development Environment](minimal-environment.md) defines common terminology used in the Nephio project.
-* How to perform [Unit testing using mocking with Mockery](unit-testing-mockery.md).


### PR DESCRIPTION
The developer guide has already been moved to to content/en/docs/guides/contributor-guides. It was inadvertently added in  PR-92 and should be deleted here.