### PR TITLE
Fix exercise links

### DIFF
--- a/content/en/docs/guides/install-guides/_index.md
+++ b/content/en/docs/guides/install-guides/_index.md
@@ -173,7 +173,7 @@ ssh <user>@<vm-address>
 
 ## Next Steps
 
-* Step through the [exercises]({{< relref "exercises.md" >}}) 
+* Step through the [Free5GC]({{< relref "exercise-1-free5gc.md" >}}) and [OAI]({{< relref "exercise-2-oai.md" >}}) exercises
 * Learn more about the [Nephio demo sandbox]({{< relref "explore-sandbox.md" >}})
 * Dig into the [user guide]({{< ref "user-guides#nephio-r1-user-guide" >}})
 * Create a [Bring-Your-Own-Cluster]({{< relref "install-on-byoc.md" >}}) Nephio Installation

--- a/content/en/docs/guides/install-guides/install-on-gcp.md
+++ b/content/en/docs/guides/install-guides/install-on-gcp.md
@@ -1384,5 +1384,5 @@ Note that the exercises using free5gc rely on Multus and on the gtp5g kernel mod
 GKE nodes. Therefore, the free5gc workloads cannot be run on this installation. You will need to alter the exercises to\
 use workloads that do not rely on that functionality in order to experiment with Nephio features.
 
-* Step through the [exercises]({{< relref "/docs/guides/user-guides/exercises.md" >}})
+* Step through the [Free5GC]({{< relref "exercise-1-free5gc.md" >}}) and [OAI]({{< relref "exercise-2-oai.md" >}}) exercises
 * Dig into the [user guide]({{< relref "/docs/guides/user-guides/_index.md" >}})

--- a/content/en/docs/guides/user-guides/helm/flux-helm.md
+++ b/content/en/docs/guides/user-guides/helm/flux-helm.md
@@ -18,9 +18,9 @@ Then, we can utilize the flux Custom Resources defined in another test kpt packa
 
 * [Nephio R1 sandbox]({{< ref "/docs/guides/install-guides/" >}}): Set up the Nephio sandbox environment.
 * [Access to the Nephio Web UI]({{< ref "/docs/guides/install-guides/#access-to-the-user-interfaces" >}})
-* [Nephio R1 sandbox workload clusters]({{< ref "/docs/guides/user-guides/exercises.md#quick-start-exercises" >}}):
-  Create/Deploy the predefined set of workload clusters by completing the quick start exercises up to and including
-  [Step 3]({{< ref "/docs/guides/user-guides/exercises.md#step-3-deploy-two-edge-clusters" >}}).
+* [Nephio R1 sandbox workload clusters]({{< ref "/docs/guides/user-guides/exercise-1-free5gc.md" >}}):
+  Create/Deploy the predefined set of workload clusters by completing the Free5GC Core quick start exercises up to and including
+  [Step 3]({{< ref "/docs/guides/user-guides/exercise-1-free5gc.md#step-3-deploy-two-edge-clusters" >}}).
 
 ### Deploying the flux-helm-controllers pkg
 


### PR DESCRIPTION
The original Free5Gc exercises were renamed and the OAI exercises were added in a previous PR. This PR fixes the broken links to the Free5GC exercises and adds links to the OAI exercises in documents where the exercise links were broken.