### PR TITLE
Adding a render hook to Hugo generation

### DIFF
--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -1,0 +1,18 @@
+{{- $img := .Page.Resources.GetMatch .Destination -}}
+{{- if and (not $img) .Page.File -}}
+{{ $path := path.Join .Page.File.Dir .Destination }}
+{{- $img = resources.Get $path -}}
+{{- end -}}
+{{- with $img -}}
+{{- $large := $img.Resize "1200x" -}}
+{{ $medium := $large.Fill "726x402" -}}
+{{ $small := $medium.Fill "458x254" -}}
+<figure class="image-caption">
+    <img alt="{{ $.Text }}" srcset="
+        {{ replace .RelPermalink "/static/" "/" | safeURL }} 458w,
+        {{ replace $medium.RelPermalink "/static/" "/" | safeURL }} 726w,
+        {{ replace $large.RelPermalink "/static/" "/" | safeURL }} 1200w" sizes="50vw" src="{{ replace $small.RelPermalink "/static/" "/images/" | safeURL }}" />
+    <figcaption>{{ with $.Title | safeHTML }}{{ . }}{{ end }}</figcaption>
+</figure>
+{{- else -}}
+<img src="{{ replace .Destination "/static/" "/" | safeURL }}" alt="{{ $.Text }}" />{{- end -}}

--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -11,7 +11,8 @@
     <img alt="{{ $.Text }}" srcset="
         {{ replace .RelPermalink "/static/" "/" | safeURL }} 458w,
         {{ replace $medium.RelPermalink "/static/" "/" | safeURL }} 726w,
-        {{ replace $large.RelPermalink "/static/" "/" | safeURL }} 1200w" sizes="50vw" src="{{ replace $small.RelPermalink "/static/" "/images/" | safeURL }}" />
+        {{ replace $large.RelPermalink "/static/" "/" | safeURL }} 1200w" sizes="50vw" src="{{ replace $small.RelPermalink "/static/" "/" | safeURL }}" />
+
     <figcaption>{{ with $.Title | safeHTML }}{{ . }}{{ end }}</figcaption>
 </figure>
 {{- else -}}

--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,0 +1,32 @@
+{{- $attrs := dict }}
+{{- $u := urls.Parse .Destination }}
+
+{{- if $u.IsAbs }}
+  {{- /* Remote */}}
+  {{- $attrs = dict "href" $u.String "rel" "external" }}
+  {{- else }}
+    {{- with $u.Path }}
+      {{- with $.Page.GetPage . }}
+        {{- /* Page */}}
+        {{- $href := .RelPermalink }}
+        {{- with $u.RawQuery }}
+          {{- $href = printf "%s?%s" $href $u.RawQuery }}
+        {{- end }}
+        {{- with $u.Fragment }}
+          {{- $href = printf "%s#%s" $href $u.Fragment }}
+        {{- end }}
+        {{- $attrs = dict "href" $href }}
+      {{- end }}
+  {{- end }}
+{{- end }}
+
+{{- with .Title }}
+  {{- $attrs = merge $attrs (dict "title" .) }}
+{{- end -}}
+
+<a
+{{- range $k, $v := $attrs }}
+  {{- printf " %s=%q" $k $v | safeHTMLAttr }}
+{{- end -}}
+>{{ .Text | safe.HTML }}</a>
+{{- /**/ -}}

--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,32 +1,10 @@
-{{- $attrs := dict }}
-{{- $u := urls.Parse .Destination }}
-
-{{- if $u.IsAbs }}
-  {{- /* Remote */}}
-  {{- $attrs = dict "href" $u.String "rel" "external" }}
-  {{- else }}
-    {{- with $u.Path }}
-      {{- with $.Page.GetPage . }}
-        {{- /* Page */}}
-        {{- $href := .RelPermalink }}
-        {{- with $u.RawQuery }}
-          {{- $href = printf "%s?%s" $href $u.RawQuery }}
-        {{- end }}
-        {{- with $u.Fragment }}
-          {{- $href = printf "%s#%s" $href $u.Fragment }}
-        {{- end }}
-        {{- $attrs = dict "href" $href }}
-      {{- end }}
-  {{- end }}
-{{- end }}
-
-{{- with .Title }}
-  {{- $attrs = merge $attrs (dict "title" .) }}
+{{ $link := .Destination }}
+{{ $isRemote := strings.HasPrefix $link "http" }}
+{{- if not $isRemote -}}
+{{ $url := urls.Parse .Destination }}
+{{- if $url.Path -}}
+{{ $fragment := "" }}
+{{- with $url.Fragment }}{{ $fragment = printf "#%s" . }}{{ end -}}
+{{- with .Page.GetPage $url.Path }}{{ $link = printf "%s%s" .RelPermalink $fragment }}{{ else }}{{ warnf "%q not found from %q" $url.Path $.Page.Path }}{{ end }}{{ end -}}
 {{- end -}}
-
-<a
-{{- range $k, $v := $attrs }}
-  {{- printf " %s=%q" $k $v | safeHTMLAttr }}
-{{- end -}}
->{{ .Text | safe.HTML }}</a>
-{{- /**/ -}}
+<a href="{{ $link | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if $isRemote }} target="_blank"{{ end }}>{{ .Text | safeHTML }}</a>


### PR DESCRIPTION
Based on this [comment](https://discourse.gohugo.io/t/replace-image-reference-link/35314/8) 
This will make MD cross reference links work in both Github and Hugo rendered page.
And Images showing in both.


Note the link at the bottom 
Before:
<img width="532" alt="1" src="https://github.com/nephio-project/docs/assets/37077655/e4925c1b-3417-4148-9600-b13f9533b3ae">
After:
<img width="532" alt="2" src="https://github.com/nephio-project/docs/assets/37077655/161e1e5a-82ed-481f-b64c-61d1432618c4">

Note the image:
<img width="532" alt="3" src="https://github.com/nephio-project/docs/assets/37077655/564629d1-be9f-4816-84f4-79761a4955ec">
