### PR TITLE
Adding API Specs

### DIFF
--- a/content/en/docs/apis.md
+++ b/content/en/docs/apis.md
@@ -1,0 +1,8 @@
+---
+title: "API Specifications"
+type: docs
+weight: 5
+description: Reference for the Nephio APIs
+---
+
+{{< iframe src="https://doc.crds.dev/github.com/nephio-project/api@v2.0.0" sub="https://doc.crds.dev/github.com/nephio-project/api@v2.0.0">}}


### PR DESCRIPTION
So far it is an iframe reference to doc.crds.dev. 

In the long run it might be better to use the [swaggerui](https://www.docsy.dev/docs/adding-content/shortcodes/#swaggerui) or the [redoc](https://www.docsy.dev/docs/adding-content/shortcodes/#redoc) options of Docsy. For these two later options we would need to have the Open API specs of the API-s somewhere. I have a feeling that at the moment we have the API-s defined in Go code and not in Open API. Is this correct @johnbelamaric ?