### PR TITLE
Update install-on-multiple-vm.md

### DIFF
--- a/content/en/docs/guides/install-guides/install-on-multiple-vm.md
+++ b/content/en/docs/guides/install-guides/install-on-multiple-vm.md
@@ -26,7 +26,7 @@ Override the default Ansible values and run the installation script in
 then run:
 ```bash
 export NEPHIO_USER=$USER
-export ANSIBLE_CMD_EXTRA_VAR_LIST="k8s.context=kubernetes-admin@cluster.local kind.enable=false host_min_vcpu=4 host_min_cpu_ram=8"
+export ANSIBLE_CMD_EXTRA_VAR_LIST="k8s.context=kubernetes-admin@cluster.local kind.enabled=false host_min_vcpu=4 host_min_cpu_ram=8"
 
 curl -fsSL https://raw.githubusercontent.com/nephio-project/test-infra/main/e2e/provision/init.sh | sudo -E bash
 ```


### PR DESCRIPTION
According to playbook in test-infra for provisioning, enabling or disabling KinD cluster shall be achieved by
`kind.enabled` not `kind.enable` ([reference](https://github.com/nephio-project/test-infra/blob/2e8de787693dcfb07f0d2e4088d3ed3ccdac1250/e2e/provision/playbooks/roles/bootstrap/README.md?plain=1#L27)).

However, the document had `kind.enable` which sets up a KinD cluster that overwrites the current kubeconfig which I had. This seems not to be an expected behavior.