### PR TITLE
Add K8S_CONTEXT label documentation

### DIFF
--- a/content/en/docs/guides/install-guides/_index.md
+++ b/content/en/docs/guides/install-guides/_index.md
@@ -96,7 +96,7 @@ sudo netplan apply
 ```
 
 ### Kick Off an Installation on VM
-The below commands make assumptions of GitHub path, GitHub branch/tag, username, K8s context, etc. See the table of variables below to change installation parameters and make changes to commands as needed.
+The commands below use default values for the GitHub path, GitHub branch/tag, username, K8s context, etc. See the table of variables below for information on how to set custom installation parameters and make changes to commands as you need to.
 
 **Kind Cluster**
 

--- a/content/en/docs/guides/install-guides/_index.md
+++ b/content/en/docs/guides/install-guides/_index.md
@@ -120,7 +120,7 @@ sudo NEPHIO_DEBUG=false   \
      NEPHIO_BRANCH=v2.0.0 \
      NEPHIO_USER=ubuntu   \
      DOCKERHUB_USERNAME=username \
-     DOCKERHUB_PASSWORD=password \
+     DOCKERHUB_TOKEN=password \
      K8S_CONTEXT=kubernetes-admin@kubernetes \
      bash
 ```

--- a/content/en/docs/guides/install-guides/_index.md
+++ b/content/en/docs/guides/install-guides/_index.md
@@ -120,6 +120,7 @@ The following environment variables can be used to configure the installation:
 | NEPHIO_REPO            | URL              | https://github.com/nephio-project/test-infra.git | URL of the repository to be used for installation |
 | NEPHIO_BRANCH          | branch or tag    | main/v2.0.0               | Tag or branch name to use in NEPHIO_REPO                                     |
 | DOCKER_REGISTRY_MIRRORS | list of URLs in JSON format |        | List of docker registry mirrors in JSON format, or empty for no mirrors to be set. Example value: ``["https://docker-registry-remote.mycompany.com", "https://docker-registry-remote2.mycompany.com"]`` |
+| K8S_CONTEXT            | K8s context      | kind-kind          | Kubernetes context for existing non-kind cluster (gathered from `kubectl config get-contexts`, for example "kubernetes-admin@kubernetes") |
 
 ### Follow the Installation on VM
 

--- a/content/en/docs/guides/install-guides/_index.md
+++ b/content/en/docs/guides/install-guides/_index.md
@@ -96,6 +96,21 @@ sudo netplan apply
 ```
 
 ### Kick Off an Installation on VM
+The below commands make assumptions of GitHub path, GitHub branch/tag, username, K8s context, etc. See the table of variables below to change installation parameters and make changes to commands as needed.
+
+**Kind Cluster**
+
+Log onto your VM and run the following command :
+
+```bash
+wget -O - https://raw.githubusercontent.com/nephio-project/test-infra/v2.0.0/e2e/provision/init.sh |  \
+sudo NEPHIO_DEBUG=false   \
+     NEPHIO_BRANCH=v2.0.0 \
+     NEPHIO_USER=ubuntu   \
+     bash
+```
+
+**Real K8s Cluster**
 
 Log onto your VM and run the following command:
 
@@ -104,6 +119,9 @@ wget -O - https://raw.githubusercontent.com/nephio-project/test-infra/v2.0.0/e2e
 sudo NEPHIO_DEBUG=false   \
      NEPHIO_BRANCH=v2.0.0 \
      NEPHIO_USER=ubuntu   \
+     DOCKERHUB_USERNAME=username \
+     DOCKERHUB_PASSWORD=password \
+     K8S_CONTEXT=kubernetes-admin@kubernetes \
      bash
 ```
 


### PR DESCRIPTION
This is contingent on, and related to https://github.com/nephio-project/test-infra/pull/269 so will be submitted as a draft for the time being. Documenting the additional variable of K8S_CONTEXT introduced in the linked PR for deploying Nephio components on non-kind clusters.

Note also that in the "Real K8s Cluster" installation instructions the branch should be updated once https://github.com/nephio-project/test-infra/pull/269 is merged and a new tag is available. 

Closes https://github.com/nephio-project/nephio/issues/577