### PR TITLE
Remove Function CR refs

### DIFF
--- a/content/en/docs/porch/contributors-guide/_index.md
+++ b/content/en/docs/porch/contributors-guide/_index.md
@@ -109,7 +109,7 @@ then run test suite against the Porch instance.
 * `make` or `make all`: builds and runs Porch [locally](../running-porch/running-locally.md)
 * `make test`: runs tests
 
-## VSCode
+## VS Code
 
 [VS Code](https://code.visualstudio.com/) works really well for editing and debugging.
 Just open VSCode from the root folder of the Porch repository and it will work fine. The folder contains the needed

--- a/content/en/docs/porch/contributors-guide/_index.md
+++ b/content/en/docs/porch/contributors-guide/_index.md
@@ -112,5 +112,5 @@ then run test suite against the Porch instance.
 ## VSCode
 
 [VS Code](https://code.visualstudio.com/) works really well for editing and debugging.
-Just open VS Code from the root folder of the Porch repository and it will work fine. The folder contains the needed
+Just open VSCode from the root folder of the Porch repository and it will work fine. The folder contains the needed
 configuration to Launch different functions of Porch.

--- a/content/en/docs/porch/contributors-guide/_index.md
+++ b/content/en/docs/porch/contributors-guide/_index.md
@@ -7,7 +7,7 @@ description:
 
 ## Changing Porch API
 
-If you change the API resources, in *api/porch/.../*.go*, update the generated code by running:
+If you change the API resources, in `api/porch/.../*.go`, update the generated code by running:
 
 ```sh
 make generate
@@ -17,23 +17,23 @@ make generate
 
 Porch comprises of several software components:
 
-* [API](https://github.com/nephio-project/porch/tree/main/api): Definition of the KRM API supported by the Porch
+* [api](https://github.com/nephio-project/porch/tree/main/api): Definition of the KRM API supported by the Porch
   extension apiserver
-* [*porchctl*](https://github.com/nephio-project/porch/tree/main/cmd/porchctl): CLI command tool for administration of
-  Porch Repository and PackageRevision custom resources.
-* [*apiserver*](https://github.com/nephio-project/porch/tree/main/pkg/apiserver): The Porch apiserver implementation, REST
-  handlers, Porch main function
-* [*engine*](https://github.com/nephio-project/porch/tree/main/pkg/engine): Core logic of Package Orchestration -
+* [porchctl](https://github.com/nephio-project/porch/tree/main/cmd/porchctl): CLI command tool for administration of
+  Porch `Repository` and `PackageRevision` custom resources.
+* [apiserver](https://github.com/nephio-project/porch/tree/main/pkg/apiserver): The Porch apiserver implementation, REST
+  handlers, Porch `main` function
+* [engine](https://github.com/nephio-project/porch/tree/main/pkg/engine): Core logic of Package Orchestration -
   operations on package contents
-* [*func*](https://github.com/nephio-project/porch/tree/main/func): KRM function evaluator microservice; exposes gRPC API
-* [*repository*](https://github.com/nephio-project/porch/blob/main/pkg/repository): Repository integration package
-* [*git*](https://github.com/nephio-project/porch/tree/main/pkg/git): Integration with Git repository.
-* [*oci*](https://github.com/nephio-project/porch/tree/main/pkg/oci): Integration with OCI repository.
-* [*cache*](https://github.com/nephio-project/porch/tree/main/pkg/cache): Package caching.
-* [*controllers*](https://github.com/nephio-project/porch/tree/main/controllers): Repository CRD. No controller;
+* [func](https://github.com/nephio-project/porch/tree/main/func): KRM function evaluator microservice; exposes gRPC API
+* [repository](https://github.com/nephio-project/porch/blob/main/pkg/repository): Repository integration package
+* [git](https://github.com/nephio-project/porch/tree/main/pkg/git): Integration with Git repository.
+* [oci](https://github.com/nephio-project/porch/tree/main/pkg/oci): Integration with OCI repository.
+* [cache](https://github.com/nephio-project/porch/tree/main/pkg/cache): Package caching.
+* [controllers](https://github.com/nephio-project/porch/tree/main/controllers): `Repository` CRD. No controller;
   Porch apiserver watches these resources for changes as repositories are (un-)registered.
-* [*test*](https://github.com/nephio-project/porch/tree/main/test): Test Git Server for Porch e2e testing, and
-  [*e2e*](https://github.com/nephio-project/porch/tree/main/test/e2e) tests.
+* [test](https://github.com/nephio-project/porch/tree/main/test): Test Git Server for Porch e2e testing, and
+  [e2e](https://github.com/nephio-project/porch/tree/main/test/e2e) tests.
 
 ## Running Porch
 
@@ -68,7 +68,7 @@ Follow the [Running Porch Locally](../running-porch/running-locally.md) guide to
 
 ## Debugging
 
-To debug Porch, run Porch locally [Running Porch Locally](../running-porch/running-locally.md), exit porch server running
+To debug Porch, run Porch locally [running-locally.md](../running-porch/running-locally.md), exit porch server running
 in the shell, and launch Porch under the debugger. VSCode debug session is pre-configured in
 [launch.json](https://github.com/nephio-project/porch/blob/main/.vscode/launch.json).
 
@@ -89,9 +89,9 @@ Some useful code pointers:
 ## Running Tests
 
 All tests can be run using `make test`. Individual tests can be run using `go test`.
-End-to-End tests assume that Porch instance is running and KUBECONFIG is configured
+End-to-End tests assume that Porch instance is running and `KUBECONFIG` is configured
 with the instance. The tests will automatically detect whether they are running against
-Porch running on local machine or k8s cluster and will start Git server appropriately,
+Porch running on local machien or k8s cluster and will start Git server appropriately,
 then run test suite against the Porch instance.
 
 ## Makefile Targets
@@ -103,13 +103,13 @@ then run test suite against the Porch instance.
 * `make push-images`: builds and pushes Porch Docker images
 * `make deployment-config`: customizes configuration which installs Porch
    in k8s cluster with correct image names, annotations, service accounts.
-   The deployment-ready configuration is copied into *./.build/deploy*
+   The deployment-ready configuration is copied into `./.build/deploy`
 * `make deploy`: deploys Porch in the k8s cluster configured with current kubectl context
 * `make push-and-deploy`: builds, pushes Porch Docker images, creates deployment configuration, and deploys Porch
 * `make` or `make all`: builds and runs Porch [locally](../running-porch/running-locally.md)
 * `make test`: runs tests
 
-## VS Code
+## VSCode
 
 [VS Code](https://code.visualstudio.com/) works really well for editing and debugging.
 Just open VS Code from the root folder of the Porch repository and it will work fine. The folder contains the needed

--- a/content/en/docs/porch/contributors-guide/dev-process.md
+++ b/content/en/docs/porch/contributors-guide/dev-process.md
@@ -62,16 +62,6 @@ curl https://localhost:4443/apis/porch.kpt.dev/v1alpha1 -k
   "groupVersion": "porch.kpt.dev/v1alpha1",
   "resources": [
     {
-      "name": "functions",
-      "singularName": "",
-      "namespaced": true,
-      "kind": "Function",
-      "verbs": [
-        "get",
-        "list"
-      ]
-    },
-    {
       "name": "packagerevisionresources",
       "singularName": "",
       "namespaced": true,

--- a/content/en/docs/porch/contributors-guide/environment-setup.md
+++ b/content/en/docs/porch/contributors-guide/environment-setup.md
@@ -116,7 +116,6 @@ packagerevs                                      config.porch.kpt.dev/v1alpha1  
 packagevariants                                  config.porch.kpt.dev/v1alpha1     true         PackageVariant
 packagevariantsets                               config.porch.kpt.dev/v1alpha2     true         PackageVariantSet
 repositories                                     config.porch.kpt.dev/v1alpha1     true         Repository
-functions                                        porch.kpt.dev/v1alpha1            true         Function
 packagerevisionresources                         porch.kpt.dev/v1alpha1            true         PackageRevisionResources
 packagerevisions                                 porch.kpt.dev/v1alpha1            true         PackageRevision
 packages                                         porch.kpt.dev/v1alpha1            true         PorchPackage

--- a/content/en/docs/porch/package-orchestration.md
+++ b/content/en/docs/porch/package-orchestration.md
@@ -8,7 +8,7 @@ description:
 ## Why
 
 Customers who want to take advantage of the benefits of [Configuration as Data](config-as-data.md) can do so today using
-a [*kpt*](https://kpt.dev) CLI and *kpt* function ecosystem, including [functions catalog](https://catalog.kpt.dev/).
+a [kpt](https://kpt.dev) CLI and kpt function ecosystem, including [functions catalog](https://catalog.kpt.dev/).
 Package authoring is possible using a variety of editors with [YAML](https://yaml.org/) support. That said, a delightful
 UI experience of WYSIWYG package authoring which supports broader package lifecycle, including package authoring with
 *guardrails*, approval workflow, package deployment, and more, is not yet available.
@@ -20,40 +20,37 @@ building the delightful UI experience supporting the configuration lifecycle.
 
 This section briefly describes core concepts of package orchestration:
 
-**Package**: Package is a collection of related configuration files containing configuration of [KRM][krm]
-resources. Specifically, configuration packages are [*kpt* packages](https://kpt.dev/).
+***Package***: Package is a collection of related configuration files containing configuration of [KRM][krm]
+**resources**. Specifically, configuration packages are [kpt packages](https://kpt.dev/).
 
-**Repository**: Repositories store packages or [functions][]. For example [git][] or [OCI][oci]. Functions may be
-associated with repositories to enforce constraints or invariants on packages (guardrails).
-([more details](#repositories))
+***Repository***: Repositories store packages. For example [git][] or [OCI][oci]. ([more details](#repositories))
 
-Packages are sequentially versioned; multiple versions of the same package may exist in a repository.
-[more details](#package-versioning))
+Packages are sequentially ***versioned***; multiple versions of the same package may exist in a repository.
+([more details](#package-versioning))
 
-A package may have a link (URL) to an upstream package (a specific version) from which it was cloned.
+A package may have a link (URL) to an ***upstream package*** (a specific version) from which it was cloned.
 ([more details](#package-relationships))
 
 Package may be in one of several lifecycle stages:
 
-* **Draft** - package is being created or edited. The package contents can be modified but package is not ready to be
+* ***Draft*** - package is being created or edited. The package contents can be modified but package is not ready to be
   used (i.e. deployed)
-* **Proposed** - author of the package proposed that the package be published
-* **Published** - the changes to the package have been approved and the package is ready to be used. Published
+* ***Proposed*** - author of the package proposed that the package be published
+* ***Published*** - the changes to the package have been approved and the package is ready to be used. Published
   packages can be deployed or cloned
 
-**Function** (specifically, [KRM functions][krm functions]) can be applied to packages to mutate or validate resources
+***Functions*** (specifically, [KRM functions][krm functions]) can be applied to packages to mutate or validate resources
 within them. Functions can be applied to a package to create specific package mutation while editing a package draft,
-functions can be added to package's *Kptfile* [pipeline][], or associated with a repository to be applied to all packages
-on changes. ([more details](#functions))
+functions can be added to package's Kptfile [pipeline][].
 
-A repository can be designated as deployment repository. Published packages in a deployment repository are
+A repository can be designated as ***deployment repository***. *Published* packages in a deployment repository are
 considered deployment-ready. ([more details](#deployment))
 
 ## Core Components of Configuration as Data Implementation
 
-The Core implementation of Configuration as Data, CaD Core, is a set of components and APIs which collectively enable:
+The Core implementation of Configuration as Data, *CaD Core*, is a set of components and APIs which collectively enable:
 
-* Registration of repositories (Git, OCI) containing *kpt* packages or functions, and discovery of packages and functions
+* Registration of repositories (Git, OCI) containing kpt packages and the discovery of packages
 * Porcelain package lifecycle, including authoring, versioning, deletion, creation and mutations of a package draft,
   process of proposing the package draft, and publishing of the approved package.
 * Package lifecycle operations such as:
@@ -73,7 +70,7 @@ At the high level, the Core CaD functionality comprises:
   * package repository management
   * package discovery, authoring and lifecycle management
 
-* [*kpt*][] - a Git-native, schema-aware, extensible client-side tool for managing KRM packages
+* [kpt][] - a Git-native, schema-aware, extensible client-side tool for managing KRM packages
 * a GitOps-based deployment mechanism (for example [Config Sync][]), which distributes and deploys configuration, and
   provides observability of the status of deployed resources
 * a task-specific UI supporting repository management, package discovery, authoring, and lifecycle
@@ -86,8 +83,8 @@ Concepts briefly introduced above are elaborated in more detail in this section.
 
 ### Repositories
 
-[*kpt*][] and [Config Sync][] currently integrate with [git][] repositories, and there is an existing design to add OCI
-support to *kpt*. Initially, the Package Orchestration service will prioritize integration with [git][], and support for
+[kpt][] and [Config Sync][] currently integrate with [git][] repositories, and there is an existing design to add OCI
+support to kpt. Initially, the Package Orchestration service will prioritize integration with [git][], and support for
 additional repository types may be added in the future as required.
 
 Requirements applicable to all repositories include: ability to store packages, their versions, and sufficient metadata
@@ -126,8 +123,8 @@ We plan to use a simple integer sequence to represent package versions.
 
 ### Package Relationships
 
-*kpt* packages support the concept of upstream. When a package is cloned from another, the new package
-(called downstream package) maintains an upstream link to the specific version of the package from which it was
+Kpt packages support the concept of ***upstream***. When a package is cloned from another, the new package
+(called ***downstream*** package) maintains an upstream link to the specific version of the package from which it was
 cloned. If a new version of the upstream package becomes available, the upstream link can be used to
 [update](https://kpt.dev/book/03-packages/05-updating-a-package) the downstream package.
 
@@ -140,40 +137,19 @@ others can be used as well.
 
 Here we highlight some key attributes of the deployment mechanism and its integration within the CaD Core:
 
-* Published packages in a deployment repository are considered ready to be deployed
+* _Published_ packages in a deployment repository are considered ready to be deployed
 * Config Sync supports deploying individual packages and whole repositories. For Git specifically that translates to a
   requirement to be able to specify repository, branch/tag/ref, and directory when instructing Config Sync to deploy a
   package.
-* Draft packages need to be identified in such a way that Config Sync can easily avoid deploying them.
+* _Draft_ packages need to be identified in such a way that Config Sync can easily avoid deploying them.
 * Config Sync needs to be able to pin to specific versions of deployable packages in order to orchestrate rollouts and
   rollbacks. This means it must be possible to GET a specific version of a package.
 * Config Sync needs to be able to discover when new versions are available for deployment.
 
-### Functions
-
-Functions, specifically [KRM functions][krm functions], are used in the CaD core to manipulate resources within
-packages.
-
-* Similar to packages, functions are stored in repositories. Some repositories (such as OCI) are more suitable for
-  storing functions than others (such as Git).
-* Function discovery will be aided by metadata associated with the function by which the function can advertise which
-  resources it acts on, whether the function is idempotent or not, whether it is a mutator or validator, etc.
-* Function repositories can be registered and subsequently, user can discover functions from the registered repositories
-  and use them as follows:
-
-Function can be:
-
-* applied imperatively to a package draft to perform specific mutation to the package's resources or meta-resources
-  (*Kptfile* etc.)
-* registered in the package's *Kptfile* function pipeline as a mutator or validator in order to be automatically run
-  as part of package rendering
-* registered at the repository level as mutator or validator. Such function then applies to all packages in the
-  repository and is evaluated whenever a change to a package in the repository occurs.
-
 ## Package Orchestration - Porch
 
 Having established the context of the CaD Core components and the overall architecture, the remainder of the document
-will focus on Porch - Package Orchestration service.
+will focus on **Porch** - Package Orchestration service.
 
 To reiterate the role of Package Orchestration service among the CaD Core components, it is:
 
@@ -181,7 +157,7 @@ To reiterate the role of Package Orchestration service among the CaD Core compon
 * [Package Discovery](#package-discovery)
 * [Package Authoring](#package-authoring) and Lifecycle
 
-In the following section we'll expand more on each of these areas. The term *client* used in these sections can be
+In the following section we'll expand more on each of these areas. The term _client_ used in these sections can be
 either a person interacting with the UI such as a web application or a command-line tool, or an automated agent or
 process.
 
@@ -209,7 +185,7 @@ The package discovery functionality of Package Orchestration service enables the
 * retrieve resources and metadata of an individual package, including latest version or any specific version or draft
   of a package, for the purpose of introspection of a single package or for comparison of contents of multiple
   versions of a package, or related packages
-* enumerate upstream packages available for creating (cloning) a downstream package
+* enumerate _upstream_ packages available for creating (cloning) a _downstream_ package
 * identify downstream packages that need to be upgraded after a change is made to an upstream package
 * identify all deployment-ready packages in a deployment repository that are ready to be synced to a deployment target
   by Config Sync
@@ -223,28 +199,28 @@ The package discovery functionality of Package Orchestration service enables the
 
 The package authoring and lifecycle functionality of the package Orchestration service enables the client to:
 
-* Create a package draft via one of the following means:
+* Create a package _draft_ via one of the following means:
 
-  * an empty draft 'from scratch' (equivalent to [`kpt pkg init`](https://kpt.dev/reference/cli/pkg/init/))
-  * clone of an upstream package (equivalent to [`kpt pkg get`](https://kpt.dev/reference/cli/pkg/get/)) from either a
+  * an empty draft 'from scratch' (equivalent to [kpt pkg init](https://kpt.dev/reference/cli/pkg/init/))
+  * clone of an upstream package (equivalent to [kpt pkg get](https://kpt.dev/reference/cli/pkg/get/)) from either a
     registered upstream repository or from another accessible, unregistered, repository
-  * edit an existing package (similar to the CLI command(s) [`kpt fn source`](https://kpt.dev/reference/cli/fn/source/) or
-    [`kpt pkg pull`](https://github.com/GoogleContainerTools/kpt/issues/2557))
+  * edit an existing package (similar to the CLI command(s) [kpt fn source](https://kpt.dev/reference/cli/fn/source/) or
+    [kpt pkg pull](https://github.com/GoogleContainerTools/kpt/issues/2557))
   * roll back / restore a package to any of its previous versions
-    ([`kpt pkg pull`](https://github.com/GoogleContainerTools/kpt/issues/2557) of a previous version)
+    ([kpt pkg pull](https://github.com/GoogleContainerTools/kpt/issues/2557) of a previous version)
 
-* Apply changes to a package draft. In general, mutations include adding/modifying/deleting any part of the package's
+* Apply changes to a package _draft_. In general, mutations include adding/modifying/deleting any part of the package's
   contents. Some specific examples include:
 
-  * add/change/delete package metadata (i.e. some properties in the *Kptfile*)
+  * add/change/delete package metadata (i.e. some properties in the `Kptfile`)
   * add/change/delete resources in the package
   * add function mutators/validators to the package's [pipeline][]
   * invoke a function imperatively on the package draft to perform a desired mutation
   * add/change/delete sub-package
   * retrieve the contents of the package for arbitrary client-side mutations (equivalent to
-    [`kpt fn source`](https://kpt.dev/reference/cli/fn/source/))
+    [kpt fn source](https://kpt.dev/reference/cli/fn/source/))
   * update/replace the package contents with new contents, for example results of a client-side mutations by a UI
-    (equivalent to [`kpt fn sink`](https://kpt.dev/reference/cli/fn/sink/))
+    (equivalent to [kpt fn sink](https://kpt.dev/reference/cli/fn/sink/))
 
 * Rebase a package onto another upstream base package
   ([detail](https://github.com/GoogleContainerTools/kpt/issues/2548)) or onto a newer version of the same package (to
@@ -254,9 +230,9 @@ The package authoring and lifecycle functionality of the package Orchestration s
   * merge conflicts, invalid package changes, guardrail violations
   * compliance of the drafted package with repository-wide invariants and guardrails
 
-* Propose for a draft package be published.
-* Apply an arbitrary decision criteria, and by a manual or automated action, approve (or reject) proposal of a draft
-  package to be published.
+* Propose for a _draft_ package be _published_.
+* Apply an arbitrary decision criteria, and by a manual or automated action, approve (or reject) proposal of a _draft_
+  package to be _published_.
 * Perform bulk operations such as:
 
   * Assisted/automated update (upgrade, rollback) of groups of packages matching specific criteria (i.e. base package
@@ -292,7 +268,7 @@ perform in order to satisfy requirements of the basic roles. For example, only p
 
 ### Porch Architecture
 
-The Package Orchestration service, Porch is designed to be hosted in a [Kubernetes](https://kubernetes.io/) cluster.
+The Package Orchestration service, **Porch** is designed to be hosted in a [Kubernetes](https://kubernetes.io/) cluster.
 
 The overall architecture is shown below, and includes also existing components (k8s apiserver and Config Sync).
 
@@ -319,34 +295,33 @@ extension API server are:
 
 Resources implemented by Porch include:
 
-* **PackageRevision** - represents the metadata of the configuration package revision stored in a package repository.
-* **PackageRevisionResources** - represents the contents of the package revision
-* **Function** - represents a [KRM function][krm functions] discovered in a registered function repository.
+* `PackageRevision` - represents the _metadata_ of the configuration package revision stored in a _package_ repository.
+* `PackageRevisionResources` - represents the _contents_ of the package revision
 
-Note that each configuration package revision is represented by a pair of resources which each present a different
+Note that each configuration package revision is represented by a _pair_ of resources which each present a different
 view (or [representation][] of the same underlying package revision.
 
-Repository registration is supported by a Repository [custom resource][crds].
+Repository registration is supported by a `Repository` [custom resource][crds].
 
-Porch server itself comprises several key components, including:
+**Porch server** itself comprises several key components, including:
 
-* The **Porch aggregated apiserver** which implements the integration into the main Kubernetes apiserver, and directly
-  serves API requests for the PackageRevision, PackageRevisionResources and Function resources.
-* Package orchestration engine which implements the package lifecycle operations, and package mutation workflows
-* **CaD Library** which implements specific package manipulation algorithms such as package rendering (evaluation of
-  package's function pipeline), initialization of a new package, etc. The CaD Library is shared with *kpt*
+* The *Porch aggregated apiserver* which implements the integration into the main Kubernetes apiserver, and directly
+  serves API requests for the `PackageRevision`, `PackageRevisionResources` resources.
+* Package orchestration *engine* which implements the package lifecycle operations, and package mutation workflows
+* *CaD Library* which implements specific package manipulation algorithms such as package rendering (evaluation of
+  package's function *pipeline*), initialization of a new package, etc. The CaD Library is shared with `kpt`
   where it likewise provides the core package manipulation algorithms.
-* **Package cache** which enables both local caching, as well as abstract manipulation of packages and their contents
+* *Package cache* which enables both local caching, as well as abstract manipulation of packages and their contents
   irrespectively of the underlying storage mechanism (Git, or OCI)
-* **Repository adapters** for Git and OCI which implement the specific logic of interacting with those types of package
+* *Repository adapters* for Git and OCI which implement the specific logic of interacting with those types of package
   repositories.
-* **Function runtime** which implements support for evaluating [*kpt* functions][functions] and multi-tier cache of
+* *Function runtime* which implements support for evaluating [kpt functions][functions] and multi-tier cache of
   functions to support low latency function evaluation
 
 #### Function Runner
 
-Function runner is a separate service responsible for evaluating [**kpt** functions][functions]. Function runner exposes
-a [gRPC](https://grpc.io/) endpoint which enables evaluating a *kpt* function on the provided configuration package.
+**Function runner** is a separate service responsible for evaluating [kpt functions][functions]. Function runner exposes
+a [gRPC](https://grpc.io/) endpoint which enables evaluating a kpt function on the provided configuration package.
 
 The gRPC technology was chosen for the function runner service because the [requirements](#grpc-api) that informed
 choice of KRM API for the Package Orchestration service do not apply. The function runner is an internal microservice,
@@ -356,29 +331,29 @@ The function runner also maintains cache of functions to support low latency fun
 
 #### CaD Library
 
-The [*kpt*](https://*kpt*.dev/) CLI already implements foundational package manipulation algorithms in order to provide the
+The [kpt](https://kpt.dev/) CLI already implements foundational package manipulation algorithms in order to provide the
 command line user experience, including:
 
-* [`kpt pkg init`](https://kpt.dev/reference/cli/pkg/init/) - create an empty, valid, KRM package
-* [`kpt pkg get`](https://kpt.dev/reference/cli/pkg/get/) - create a downstream package by cloning an upstream package;
+* [kpt pkg init](https://kpt.dev/reference/cli/pkg/init/) - create an empty, valid, KRM package
+* [kpt pkg get](https://kpt.dev/reference/cli/pkg/get/) - create a downstream package by cloning an upstream package;
   set up the upstream reference of the downstream package
-* [`kpt pkg update`](https://kpt.dev/reference/cli/pkg/update/) - update the downstream package with changes from new
+* [kpt pkg update](https://kpt.dev/reference/cli/pkg/update/) - update the downstream package with changes from new
   version of upstream, 3-way merge
-* [`kpt fn eval`](https://kpt.dev/reference/cli/fn/eval/) - evaluate a *kpt* function on a package
-* [`kpt fn render`](https://kpt.dev/reference/cli/fn/render/) - render the package by executing the function pipeline of
+* [kpt fn eval](https://kpt.dev/reference/cli/fn/eval/) - evaluate a kpt function on a package
+* [kpt fn render](https://kpt.dev/reference/cli/fn/render/) - render the package by executing the function pipeline of
   the package and its nested packages
-* [`kpt fn source`](https://kpt.dev/reference/cli/fn/source/) and [`kpt fn sink`](https://kpt.dev/reference/cli/fn/sink/) -
-  read package from local disk as a ResourceList and write package represented as ResourcesList into local disk
+* [kpt fn source](https://kpt.dev/reference/cli/fn/source/) and [kpt fn sink](https://kpt.dev/reference/cli/fn/sink/) -
+  read package from local disk as a `ResourceList` and write package represented as `ResourcesList` into local disk
 
 The same set of primitives form the foundational building blocks of the package orchestration service. Further, the
 package orchestration service combines these primitives into higher-level operations (for example, package orchestrator
 renders packages automatically on changes, future versions will support bulk operations such as upgrade of multiple
 packages, etc).
 
-The implementation of the package manipulation primitives in *kpt* was refactored (with initial refactoring completed, and
+The implementation of the package manipulation primitives in kpt was refactored (with initial refactoring completed, and
 more to be performed as needed) in order to:
 
-* create a reusable CaD library, usable by both *kpt* CLI and Package Orchestration service
+* create a reusable CaD library, usable by both kpt CLI and Package Orchestration service
 * create abstractions for dependencies which differ between CLI and Porch, most notable are dependency on Docker for
   function evaluation, and dependency on the local file system for package rendering.
 
@@ -389,19 +364,20 @@ Over time, the CaD Library will provide the package manipulation primitives:
 * perform 3-way merge (update)
 * render - core package rendering algorithm using a pluggable function evaluator to support:
 
-  * function evaluation via Docker (used by *kpt* CLI)
+  * function evaluation via Docker (used by kpt CLI)
   * function evaluation via an RPC to a service or appropriate function sandbox
   * high-performance evaluation of trusted, built-in, functions without sandbox
 
 * heal configuration (restore comments after lossy transformation)
 
-and both *kpt* CLI and Porch will consume the library. This approach will allow leveraging the investment already made
-into the high quality package manipulation primitives, and enable functional parity between *KPT* CLI and Package
+and both kpt CLI and Porch will consume the library. This approach will allow leveraging the investment already made
+into the high quality package manipulation primitives, and enable functional parity between KPT CLI and Package
 Orchestration service.
 
 ## User Guide
 
-Find the Porch User Guide in a dedicated [document](using-porch/usage-porch-kpt-cli.md).
+Find the Porch User Guide in a dedicated
+[document](https://github.com/kptdev/kpt/blob/main/site/guides/porch-user-guide.md).
 
 ## Open Issues/Questions
 

--- a/content/en/docs/porch/running-porch/running-locally.md
+++ b/content/en/docs/porch/running-porch/running-locally.md
@@ -99,7 +99,6 @@ export KUBECONFIG=${PWD}/deployments/local/kubeconfig
 kubectl api-resources | grep porch
 
 repositories                  config.porch.kpt.dev/v1alpha1          true         Repository
-functions                     porch.kpt.dev/v1alpha1                 true         Function
 packagerevisionresources      porch.kpt.dev/v1alpha1                 true         PackageRevisionResources
 packagerevisions              porch.kpt.dev/v1alpha1                 true         PackageRevision
 ```

--- a/content/en/docs/porch/running-porch/running-on-GKE.md
+++ b/content/en/docs/porch/running-porch/running-on-GKE.md
@@ -96,7 +96,6 @@ Expected output will include:
 
 ```bash
 repositories                                   config.porch.kpt.dev/v1alpha1          true         Repository
-functions                                      porch.kpt.dev/v1alpha1                 true         Function
 packagerevisionresources                       porch.kpt.dev/v1alpha1                 true         PackageRevisionResources
 packagerevisions                               porch.kpt.dev/v1alpha1                 true         PackageRevision
 ```

--- a/content/en/docs/porch/using-porch/install-and-using-porch.md
+++ b/content/en/docs/porch/using-porch/install-and-using-porch.md
@@ -247,7 +247,6 @@ packagerevs                                    config.porch.kpt.dev/v1alpha1    
 packagevariants                                config.porch.kpt.dev/v1alpha1          true         PackageVariant
 packagevariantsets                             config.porch.kpt.dev/v1alpha2          true         PackageVariantSet
 repositories                                   config.porch.kpt.dev/v1alpha1          true         Repository
-functions                                      porch.kpt.dev/v1alpha1                 true         Function
 packagerevisionresources                       porch.kpt.dev/v1alpha1                 true         PackageRevisionResources
 packagerevisions                               porch.kpt.dev/v1alpha1                 true         PackageRevision
 packages                                       porch.kpt.dev/v1alpha1                 true         Package
@@ -454,7 +453,6 @@ The full list of Nephio CRDs is as below:
 ```bash
 kubectl api-resources --api-group=porch.kpt.dev         
 NAME                       SHORTNAMES   APIVERSION               NAMESPACED   KIND
-functions                               porch.kpt.dev/v1alpha1   true         Function
 packagerevisionresources                porch.kpt.dev/v1alpha1   true         PackageRevisionResources
 packagerevisions                        porch.kpt.dev/v1alpha1   true         PackageRevision
 packages                                porch.kpt.dev/v1alpha1   true         Package

--- a/content/en/docs/porch/using-porch/usage-porch-kpt-cli.md
+++ b/content/en/docs/porch/using-porch/usage-porch-kpt-cli.md
@@ -6,7 +6,7 @@ description:
 ---
 
 
-This document is focused on using Porch via the *kpt* CLI.
+This document is focused on using Porch via the `kpt` CLI.
 
 Installation of Porch, including prerequisites, is covered in a [dedicated document](install-and-using-porch.md).
 
@@ -14,21 +14,21 @@ Installation of Porch, including prerequisites, is covered in a [dedicated docum
 
 To use Porch, you will need:
 
-* [*kpt*](https://kpt.dev)
-* [*kubectl*](https://kubernetes.io/docs/tasks/tools/#kubectl)
-* [*gcloud*](https://cloud.google.com/sdk/gcloud) (if running on GKE)
+* [`kpt`](https://kpt.dev)
+* [`kubectl`](https://kubernetes.io/docs/tasks/tools/#kubectl)
+* [`gcloud`](https://cloud.google.com/sdk/gcloud) (if running on GKE)
 
-Make sure that your *kubectl* context is set up for *kubectl* to interact with the correct Kubernetes instance (see
+Make sure that your `kubectl` context is set up for `kubectl` to interact with the correct Kubernetes instance (see
 [installation instructions](install-and-using-porch.md) or the [running-locally](../running-porch/running-locally.md)
 guide for details).
 
-To check whether *kubectl* is configured with your Porch cluster (or local instance), run:
+To check whether `kubectl` is configured with your Porch cluster (or local instance), run:
 
 ```bash
 kubectl api-resources | grep porch
 ```
 
-You should see the following four resources listed:
+You should see the following four resourceds listed:
 
 ```bash
 repositories                  config.porch.kpt.dev/v1alpha1          true         Repository
@@ -41,21 +41,19 @@ functions                     porch.kpt.dev/v1alpha1                 true       
 
 Porch server manages the following resources:
 
-1. **repositories**: a repository (Git or OCI) can be registered with Porch to support discovery or management of KRM
-   configuration packages in those repositories, or discovery of KRM functions in those repositories.
-2. **packagerevisions**: a specific revision of a KRM configuration package managed by Porch in one of the registered
-   repositories. This resource represents a metadata view of the KRM configuration package.
-3. **packagerevisionresources**: this resource represents the contents of the configuration package (KRM resources
+1. `repositories`: a repository (Git or OCI) can be registered with Porch to support discovery or management of KRM
+   configuration packages in those repositories.
+2. `packagerevisions`: a specific revision of a KRM configuration package managed by Porch in one of the registered
+   repositories. This resource represents a _metadata view_ of the KRM configuration package.
+3. `packagerevisionresources`: this resource represents the contents of the configuration package (KRM resources
    contained in the package)
-4. **functions**: function resource represents a KRM function discovered in a repository registered with Porch. Functions
-   are only supported with OCI repositories.
 
 {{% alert title="Note" color="primary" %}}
 
-packagerevisions and packagerevisionresources represent different views of the same underlying KRM
-configuration package. packagerevisions represents the package metadata, and packagerevisionresources represents the
-package content. The matching resources share the same name (as well as API group and version:
-*porch.kpt.dev/v1alpha1*) and differ in resource kind (*PackageRevision* and *PackageRevisionResources* respectively).
+`packagerevisions` and `packagerevisionresources` represent different _views_ of the same underlying KRM
+configuration package. `packagerevisions` represents the package metadata, and `packagerevisionresources` represents the
+package content. The matching resources share the same `name` (as well as API group and version:
+`porch.kpt.dev/v1alpha1`) and differ in resource kind (`PackageRevision` and `PackageRevisionResources` respectively).
 
 {{% /alert %}}
 
@@ -93,7 +91,7 @@ $ kpt alpha repo register \
 All command line flags supported:
 
 * `--directory` - Directory within the repository where to look for packages.
-* `--branch` - Branch in the repository where finalized packages are committed (defaults to *main*).
+* `--branch` - Branch in the repository where finalized packages are committed (defaults to `main`).
 * `--name` - Name of the package repository Kubernetes resource. If unspecified, will default to the name portion (last
   segment) of the repository URL (`blueprint` in the example above)
 * `--description` - Brief description of the package repository.
@@ -102,9 +100,9 @@ All command line flags supported:
 * `--repo-basic-username` - Username for repository authentication using basic auth.
 * `--repo-basic-password` - Password for repository authentication using basic auth.
 
-Additionally, common *kubectl* command line flags for controlling aspects of
+Additionally, common `kubectl` command line flags for controlling aspects of
 interaction with the Kubernetes apiserver, logging, and more (this is true for
-all *kpt* CLI commands which interact with Porch).
+all `kpt` CLI commands which interact with Porch).
 
 Use the `kpt alpha repo get` command to query registered repositories:
 
@@ -116,7 +114,7 @@ blueprints   git   Package              True   https://github.com/platkrm/bluepr
 deployments  git   Package  true        True   https://github.com/platkrm/deployments.git
 ```
 
-The `kpt alpha <group> get` commands support common *kubectl*
+The `kpt alpha <group> get` commands support common `kubectl`
 [flags](https://kubernetes.io/docs/reference/kubectl/cheatsheet/#formatting-output) to format output, for example
 `kpt alpha repo get --output=yaml`.
 
@@ -129,7 +127,7 @@ $ kpt alpha repo unregister deployments --namespace default
 ## Package Discovery And Introspection
 
 The `kpt alpha rpkg` command group contains commands for interacting with packages managed by the Package Orchestration
-service. the r prefix used in the command group name stands for 'remote'.
+service. the `r` prefix used in the command group name stands for 'remote'.
 
 The `kpt alpha rpkg get` command list the packages in registered repositories:
 
@@ -145,16 +143,16 @@ blueprints-421a5b5e43b03bc697d96f471929efc6ba3f54b3  istions  v2             v2 
 ...
 ```
 
-The LATEST column indicates whether the package revision is the latest among the revisions of the same package. In the
-output above, v2 is the latest revision of *istions* package and v1 is the latest revision of *basens* package.
+The `LATEST` column indicates whether the package revision is the latest among the revisions of the same package. In the
+output above, `v2` is the latest revision of `istions` package and `v1` is the latest revision of `basens` package.
 
-The LIFECYCLE column indicates the lifecycle stage of the package revision, one of: Published, Draft or
-Proposed.
+The `LIFECYCLE` column indicates the lifecycle stage of the package revision, one of: `Published`, `Draft` or
+`Proposed`.
 
-The REVISION column indicates the revision of the package. Revisions are assigned when a package is Published and
-starts at v1.
+The `REVISION` column indicates the revision of the package. Revisions are assigned when a package is `Published` and
+starts at `v1`.
 
-The WORKSPACENAME column indicates the workspace name of the package. The workspace name is assigned when a draft
+The `WORKSPACENAME` column indicates the workspace name of the package. The workspace name is assigned when a draft
 revision is created and is used as the branch name for proposed and draft package revisions. The workspace name must be
 must be unique among package revisions in the same package.
 
@@ -169,7 +167,7 @@ Therefore, the names of the Kubernetes resources representing package revisions 
 
 
 Simple filtering of package revisions by name (substring) and revision (exact match) is supported by the CLI using
---name and --revision flags:
+`--name` and `--revision` flags:
 
 ```bash
 $ kpt alpha rpkg get --name istio --revision=v2
@@ -178,7 +176,7 @@ NAME                                                 PACKAGE  WORKSPACENAME  REV
 blueprints-421a5b5e43b03bc697d96f471929efc6ba3f54b3  istions  v2             v2        true    Published  blueprints
 ```
 
-The common *kubectl* flags that control output format are available as well:
+The common `kubectl` flags that control output format are available as well:
 
 ```bash
 $ kpt alpha rpkg get blueprints-421a5b5e43b03bc697d96f471929efc6ba3f54b3 -ndefault -oyaml
@@ -201,7 +199,7 @@ spec:
 
 The `kpt alpha rpkg pull` command can be used to read the package resources.
 
-The command can be used to print the package revision resources as ResourceList to stdout, which enables
+The command can be used to print the package revision resources as `ResourceList` to `stdout`, which enables
 [chaining](https://kpt.dev/book/04-using-functions/02-imperative-function-execution?id=chaining-functions-using-the-unix-pipe)
 evaluation of functions on the package revision pulled from the Package Orchestration server.
 
@@ -258,7 +256,7 @@ deployments-c32b851b591b860efda29ba0e006725c8c1f7764  new-package  v1           
 ...
 ```
 
-The new package is created in the Draft lifecycle stage. This is true also for all commands that create new package
+The new package is created in the `Draft` lifecycle stage. This is true also for all commands that create new package
 revision (`init`, `clone` and `copy`).
 
 Additional flags supported by the `kpt alpha rpkg init` command are:
@@ -270,7 +268,7 @@ Additional flags supported by the `kpt alpha rpkg init` command are:
 * `--site` - Link to page with information about the package.
 
 
-Use `kpt alpha rpkg clone` command to create a *downstream* package by cloning an *upstream* package:
+Use `kpt alpha rpkg clone` command to create a _downstream_ package by cloning an _upstream_ package:
 
 ```bash
 $ kpt alpha rpkg clone blueprints-421a5b5e43b03bc697d96f471929efc6ba3f54b3 istions-clone \
@@ -307,11 +305,11 @@ The flags supported by the `kpt alpha rpkg clone` command are:
   package is located.
 * `--ref` - Ref in the upstream repository where the upstream package is
   located. This can be a branch, tag, or SHA.
-* `--repository` - Repository to which package will be cloned (*downstream*
+* `--repository` - Repository to which package will be cloned (downstream
   repository).
 * `--workspace` - Workspace to assign to the downstream package.
 * `--strategy` - Update strategy that should be used when updating this package;
-  one of: resource-merge, fast-forward, force-delete-replace.
+  one of: `resource-merge`, `fast-forward`, `force-delete-replace`.
 
 
 The `kpt alpha rpkg copy` command can be used to create a new revision of an existing package. It is a means to
@@ -328,7 +326,7 @@ NAME                                                  PACKAGE   WORKSPACENAME   
 blueprints-bf11228f80de09f1a5dd9374dc92ebde3b503689   istions   v3                         false    Draft       blueprints
 ```
 
-The `kpt alpha rpkg push` command can be used to update the resources (package contents) of a package *draft*:
+The `kpt alpha rpkg push` command can be used to update the resources (package contents) of a package _draft_:
 
 ```bash
 $ kpt alpha rpkg pull \
@@ -376,9 +374,9 @@ blueprints-bf11228f80de09f1a5dd9374dc92ebde3b503689 deleted
 
 ## Package Lifecycle and Approval Flow
 
-Authoring is performed on the package revisions in the Draft lifecycle stage. Before a package can be deployed or
-cloned, it must be Published. The approval flow is the process by which the package is advanced from Draft state
-through Proposed state and finally to Published lifecycle stage.
+Authoring is performed on the package revisions in the _Draft_ lifecycle stage. Before a package can be deployed or
+cloned, it must be _Published_. The approval flow is the process by which the package is advanced from _Draft_ state
+through _Proposed_ state and finally to _Published_ lifecycle stage.
 
 The commands used to manage package lifecycle stages include:
 
@@ -386,7 +384,7 @@ The commands used to manage package lifecycle stages include:
 * `approve` - Approves a proposal to finalize a package revision.
 * `reject`  - Rejects a proposal to finalize a package revision
 
-In the [Authoring Packages](#authoring-packages) section above we created several draft packages and in this section
+In the [Authoring Packages](#authoring-packages) section above we created several _draft_ packages and in this section
 we will create proposals for publishing some of them.
 
 ```bash
@@ -416,7 +414,7 @@ deployments-11ca1db650fa4bfa33deeb7f488fbdc50cdb3b82   istions-clone   v1       
 deployments-c32b851b591b860efda29ba0e006725c8c1f7764   new-package     v1                         false    Proposed    deployments
 ```
 
-At this point, a person in platform administrator role, or even an automated process, will review and either approve
+At this point, a person in _platform administrator_ role, or even an automated process, will review and either approve
 or reject the proposals. To aid with the decision, the platform administrator may inspect the package contents using the
 commands above, such as `kpt alpha rpkg pull`.
 
@@ -442,18 +440,18 @@ deployments-11ca1db650fa4bfa33deeb7f488fbdc50cdb3b82   istions-clone   v1       
 deployments-c32b851b591b860efda29ba0e006725c8c1f7764   new-package     v1                         false    Draft       deployments
 ```
 
-Observe that the rejected proposal returned the package revision back to Draft lifecycle stage. The package whose
-proposal was approved is now in Published state.
+Observe that the rejected proposal returned the package revision back to _Draft_ lifecycle stage. The package whose
+proposal was approved is now in _Published_ state.
 
 ## Deploying a Package
 
-Commands used in the context of deploying a package include are in the `kpt alpha sync` command group (named sync to
+Commands used in the context of deploying a package include are in the `kpt alpha sync` command group (named `sync` to
 emphasize that Config Sync is the deploying mechanism and that configuration is being synchronized with the actuation
 target as a means of deployment) and include:
 
 * `create` - Creates a sync of a package in the deployment cluster.
-* `del` - Deletes the package rootsync.
-* `get` - Gets a rootsync resource with which package was deployed.
+* `del` - Deletes the package RootSync.
+* `get` - Gets a RootSync resource with which package was deployed.
 
 ```bash
 # Make sure Config Sync is configured to use multirepo mode
@@ -472,7 +470,7 @@ $ kpt alpha sync create -ndefault \
   --package=deployments-11ca1db650fa4bfa33deeb7f488fbdc50cdb3b82 \
   sync-istions-clone
 
-Created rootsync config-management-system/sync-istions-clone
+Created RootSync config-management-system/sync-istions-clone
 
 # Get the status of the sync resource
 $ kpt alpha sync get sync-istions-clone -oyaml


### PR DESCRIPTION
The Function CRD and Repo content tyoe has been removed from Porch. This cleans up any remaining refs.