### PR TITLE
Add missing APIs to be enabled in the documentation

### DIFF
--- a/content/en/docs/guides/install-guides/install-on-gcp.md
+++ b/content/en/docs/guides/install-guides/install-on-gcp.md
@@ -139,7 +139,9 @@ gcloud services enable krmapihosting.googleapis.com \
     serviceusage.googleapis.com \
     iam.googleapis.com \
     gkehub.googleapis.com \
-    anthosconfigmanagement.googleapis.com
+    anthosconfigmanagement.googleapis.com \
+    anthos.googleapis.com \
+    sourcerepo.googleapis.com
 ```
 
 


### PR DESCRIPTION
Added missing APIs that are required when setting up a new environment with the documentation steps.