### PR TITLE
Remove ubuntu20.04 support

### DIFF
--- a/content/en/docs/guides/install-guides/_index.md
+++ b/content/en/docs/guides/install-guides/_index.md
@@ -27,10 +27,11 @@ Platform (GCP). You will also need to have gcloud installed on your local enviro
 ```bash
 gcloud compute instances create --machine-type e2-standard-16 \
                                     --boot-disk-size 200GB \
-                                    --image-family=ubuntu-2004-lts \
+                                    --image-family=ubuntu-2204-lts \
                                     --image-project=ubuntu-os-cloud \
-                                    --metadata=startup-script-url=https://raw.githubusercontent.com/nephio-project/test-infra/v3.0.0/e2e/provision/init.sh,nephio-test-infra-branch=v3.0.0 \
-                                    nephio-r3-e2e
+                                    --metadata=startup-script-url=https://raw.githubusercontent.com/nephio-project/test-infra/main/e2e/provision/init.sh,nephio-test-infra-branch=main \
+                                    nephio-main-e2e
+
 ```
 
 {{% alert title="Note" color="primary" %}}
@@ -46,7 +47,7 @@ reach a network-accessible state. Then log in with SSH and investigate the scrip
 tail:
 
 ```bash
-gcloud compute ssh ubuntu@nephio-r3-e2e -- \
+gcloud compute ssh ubuntu@nephio-main-e2e -- \
                 sudo journalctl -u google-startup-scripts.service --follow
 ```
 
@@ -58,7 +59,7 @@ This installation has been verified on VMs running on vSphere, OpenStack, AWS, a
 
 Order or create a VM with the following specifications:
 
-- Linux Flavour: Ubuntu-20.04-focal
+- Linux Flavour: Ubuntu-22.04-focal
 - a minimum of eight cores and recommended 16 Cores
 - 32 GB memory
 - a disk size of 200 GB
@@ -98,9 +99,9 @@ installation parameters and make changes to commands as required.
 Log on to your VM and run the following command :
 
 ```bash
-wget -O - https://raw.githubusercontent.com/nephio-project/test-infra/v3.0.0/e2e/provision/init.sh |  \
+wget -O - https://raw.githubusercontent.com/nephio-project/test-infra/main/e2e/provision/init.sh |  \
 sudo NEPHIO_DEBUG=false   \
-     NEPHIO_BRANCH=v3.0.0 \
+     NEPHIO_BRANCH=main \
      NEPHIO_USER=ubuntu   \
      bash
 ```
@@ -117,9 +118,9 @@ and *repository* packages.
 
 
 ```bash
-wget -O - https://raw.githubusercontent.com/nephio-project/test-infra/v3.0.0/e2e/provision/init.sh |  \
+wget -O - https://raw.githubusercontent.com/nephio-project/test-infra/main/e2e/provision/init.sh |  \
 sudo NEPHIO_DEBUG=false   \
-     NEPHIO_BRANCH=v3.0.0 \
+     NEPHIO_BRANCH=main \
      NEPHIO_USER=ubuntu   \
      DOCKERHUB_USERNAME=username \
      DOCKERHUB_TOKEN=password \
@@ -138,7 +139,7 @@ The following environment variables can be used to configure the installation:
 | *DOCKERHUB_USERNAME*      | alpha-num string |                    | This variable specifies the Docker Hub username.                             |
 | *DOCKERHUB_TOKEN*         | alpha-num string |                    | This variable specifies the password or token.                               |
 | *NEPHIO_REPO*             | URL              | https://github.com/nephio-project/test-infra.git | This variable specifies the URL of the repository to be used for installation. |
-| *NEPHIO_BRANCH*           | branch           | main/v3.0.0        | This variable specifies the tag or branch name to use in NEPHIO_REPO         |
+| *NEPHIO_BRANCH*           | branch           | main/v4.0.0        | This variable specifies the tag or branch name to use in NEPHIO_REPO         |
 | *DOCKER_REGISTRY_MIRRORS* | List of URLs in JSON format |         | This variable specifies the list of Docker registry mirrors in JSON format. If there are no mirrors to be set, then the variable remains empty. Here are two example values: ``["https://docker-registry-remote.mycompany.com", "https://docker-registry-remote2.mycompany.com"]``|
 | *K8S_CONTEXT*             | K8s context      | kind-kind          | This variable defines the Kubernetes context for the existing non-kind cluster (gathered from `kubectl config get-contexts`, for example, *kubernetes-admin@kubernetes*). |
 
@@ -157,7 +158,7 @@ Once the installation is complete, log in with SSH and forward the port to the u
 Using the GCE:
 
 ```bash
-gcloud compute ssh ubuntu@nephio-r3-e2e -- \
+gcloud compute ssh ubuntu@nephio-main-e2e -- \
                 -L 7007:localhost:7007 \
                 -L 3000:172.18.0.200:3000 \
                 kubectl port-forward --namespace=nephio-webui svc/nephio-webui 7007
@@ -185,7 +186,7 @@ You may want a second SSH window open to run `kubectl` commands, and so on, with
 Using the GCE:
 
 ```bash
-gcloud compute ssh ubuntu@nephio-r3-e2e
+gcloud compute ssh ubuntu@nephio-main-e2e
 ```
 
 Using a VM:

--- a/content/en/docs/guides/install-guides/common-components.md
+++ b/content/en/docs/guides/install-guides/common-components.md
@@ -14,7 +14,7 @@ This page is draft and the separation of the content to different categories is 
 
 {{% alert title="Note" color="primary" %}}
 
-If you want to use a version other than that of v3.0.0 of Nephio *catalog* repository, then replace the *@origin/v3.0.0*
+If you want to use a version other than that of main of Nephio *catalog* repository, then replace the *@origin/main*
 suffix on the package URLs on the `kpt pkg get` commands below with the tag/branch of the version you wish to use.
 
 While using kpt you can [either pull a branch or a tag](https://kpt.dev/book/03-packages/01-getting-a-package) from a
@@ -22,9 +22,9 @@ git repository. By default it pulls the tag. In case, you have branch with the s
 
 ```bash
 #pull a branch 
-kpt pkg get --for-deployment <git-repository>@origin/v3.0.0
+kpt pkg get --for-deployment <git-repository>@origin/main
 #pull a tag
-kpt pkg get --for-deployment <git-repository>@v3.0.0
+kpt pkg get --for-deployment <git-repository>@v4.0.0
 ```
 
 {{% /alert %}}
@@ -39,7 +39,7 @@ packages. It also provides the API layer that shields the Nephio components from
 Fetch the package using `kpt`, and run any `kpt` functions, and then apply the package:
 
 ```bash
-kpt pkg get --for-deployment https://github.com/nephio-project/catalog/nephio/core/porch@origin/v3.0.0
+kpt pkg get --for-deployment https://github.com/nephio-project/catalog/nephio/core/porch@origin/main
 kpt fn render porch
 kpt live init porch
 kpt live apply porch --reconcile-timeout=15m --output=table
@@ -54,7 +54,7 @@ well as operators that can provision repositories and bootstrap new clusters int
 To install the Nephio Operators, repeat the `kpt` steps, but for that package:
 
 ```bash
-kpt pkg get --for-deployment https://github.com/nephio-project/catalog.git/nephio/core/nephio-operator@origin/v3.0.0
+kpt pkg get --for-deployment https://github.com/nephio-project/catalog.git/nephio/core/nephio-operator@origin/main
 ```
 
 The Nephio Operator package by default uses the Gitea instance at *172.18.0.200:3000* as 
@@ -97,7 +97,7 @@ To install it on the management cluster, we again follow the same process.
 Later, we will configure it to point to the *mgmt* repository:
 
 ```bash
-kpt pkg get --for-deployment https://github.com/nephio-project/catalog.git/nephio/core/configsync@origin/v3.0.0
+kpt pkg get --for-deployment https://github.com/nephio-project/catalog.git/nephio/core/configsync@origin/main
 kpt fn render configsync
 kpt live init configsync
 kpt live apply configsync --reconcile-timeout=15m --output=table
@@ -109,7 +109,7 @@ The repositories with the Nephio packages used in the exercises are available to
 convenience. This will install repository resources pointing directly to the GitHub repositories, with read-only access.
 
 ```bash
-kpt pkg get --for-deployment https://github.com/nephio-project/catalog.git/nephio/optional/stock-repos@origin/v3.0.0
+kpt pkg get --for-deployment https://github.com/nephio-project/catalog.git/nephio/optional/stock-repos@origin/main
 kpt fn render stock-repos
 kpt live init stock-repos
 kpt live apply stock-repos --reconcile-timeout=15m --output=table

--- a/content/en/docs/guides/install-guides/common-dependencies.md
+++ b/content/en/docs/guides/install-guides/common-dependencies.md
@@ -12,7 +12,7 @@ installation, the CRDs that come along with them are necessary.
 
 {{% alert title="Note" color="primary" %}}
 
-If you want to use a version other than that of v3.0.0 of Nephio *catalog* repository, then replace the *@origin/v3.0.0*
+If you want to use a version other than that of v4.0.0 of Nephio *catalog* repository, then replace the *@origin/main*
 suffix on the package URLs on the `kpt pkg get` commands below with the tag/branch of the version you wish to use.
 
 While using kpt you can [either pull a branch or a tag](https://kpt.dev/book/03-packages/01-getting-a-package) from a
@@ -20,9 +20,9 @@ git repository. By default it pulls the tag. In case, you have branch with the s
 
 ```bash
 #pull a branch 
-kpt pkg get --for-deployment <git-repository>@origin/v3.0.0
+kpt pkg get --for-deployment <git-repository>@origin/main
 #pull a tag
-kpt pkg get --for-deployment <git-repository>@v3.0.0
+kpt pkg get --for-deployment <git-repository>@v4.0.0
 ```
 
 {{% /alert %}}
@@ -33,7 +33,7 @@ This component is a controller for applying configuration to routers and
 switches.
 
 ```bash
-kpt pkg get --for-deployment https://github.com/nephio-project/catalog.git/nephio/optional/network-config@origin/v3.0.0
+kpt pkg get --for-deployment https://github.com/nephio-project/catalog.git/nephio/optional/network-config@origin/main
 kpt fn render network-config
 kpt live init network-config
 kpt live apply network-config --reconcile-timeout=15m --output=table
@@ -44,7 +44,7 @@ kpt live apply network-config --reconcile-timeout=15m --output=table
 The resource backend provides IP and VLAN allocation.
 
 ```bash
-kpt pkg get --for-deployment https://github.com/nephio-project/catalog.git/nephio/optional/resource-backend@origin/v3.0.0
+kpt pkg get --for-deployment https://github.com/nephio-project/catalog.git/nephio/optional/resource-backend@origin/main
 kpt fn render resource-backend
 kpt live init resource-backend
 kpt live apply resource-backend --reconcile-timeout=15m --output=table
@@ -57,7 +57,7 @@ which are getting deployed or are already deployed on the cluster. Either you ca
 then you can follow below steps:
 
 ```bash
-kpt pkg get --for-deployment https://github.com/nephio-project/catalog.git/distros/sandbox/gitea@origin/v3.0.0
+kpt pkg get --for-deployment https://github.com/nephio-project/catalog.git/distros/sandbox/gitea@origin/main
 kpt fn render gitea
 kpt live init gitea
 kpt live apply gitea --reconcile-timeout 15m --output=table

--- a/content/en/docs/guides/install-guides/install-on-gce.md
+++ b/content/en/docs/guides/install-guides/install-on-gce.md
@@ -22,15 +22,17 @@ You will need an account in GCP and *gcloud* installed on your local environment
 ```bash
 gcloud compute instances create --machine-type e2-standard-16 \
                                     --boot-disk-size 200GB \
-                                    --image-family=ubuntu-2004-lts \
+                                    --image-family=ubuntu-2204-lts \
                                     --image-project=ubuntu-os-cloud \
-                                    --metadata=startup-script-url=https://raw.githubusercontent.com/nephio-project/test-infra/v3.0.0/e2e/provision/init.sh,nephio-test-infra-branch=v3.0.0 \
-                                    nephio-r3-e2e
+                                    --metadata=startup-script-url=https://raw.githubusercontent.com/nephio-project/test-infra/main/e2e/provision/init.sh,nephio-test-infra-branch=main \
+                                    nephio-main-e2e
 ```
 
 {{% alert title="Note" color="primary" %}}
 
 e2-standard-16 is recommended and e2-standard-8 is minimum.
+
+**NOTE**: Not yet tested on Ubuntu 24.
 
 {{% /alert %}}
 
@@ -41,7 +43,7 @@ seconds to reach a network accessible state, and then SSH in and tail the
 startup script execution:
 
 ```bash
-gcloud compute ssh ubuntu@nephio-r3-e2e -- \
+gcloud compute ssh ubuntu@nephio-main-e2e -- \
                 sudo journalctl -u google-startup-scripts.service --follow
 ```
 
@@ -51,7 +53,7 @@ Once it is completed, SSH in and port forward the port to the UI (7007) and to
 Gitea's HTTP interface, if desired (3000):
 
 ```bash
-gcloud compute ssh ubuntu@nephio-r3-e2e -- \
+gcloud compute ssh ubuntu@nephio-main-e2e -- \
                 -L 7007:localhost:7007 \
                 -L 3000:172.18.0.200:3000 \
                 kubectl port-forward --namespace=nephio-webui svc/nephio-webui 7007
@@ -69,7 +71,7 @@ without the port forwarding (which would fail if you try to open a second SSH
 connection with that setting).
 
 ```bash
-gcloud compute ssh ubuntu@nephio-r3-e2e
+gcloud compute ssh ubuntu@nephio-main-e2e
 ```
 
 ## Next Steps

--- a/content/en/docs/guides/install-guides/install-on-multiple-vm.md
+++ b/content/en/docs/guides/install-guides/install-on-multiple-vm.md
@@ -39,7 +39,7 @@ The below steps have to be repeated for each workload cluster:
 Install *config-sync* using:
 
 ```bash
-kpt pkg get --for-deployment https://github.com/nephio-project/catalog.git/nephio/core/configsync@origin/v3.0.0
+kpt pkg get --for-deployment https://github.com/nephio-project/catalog.git/nephio/core/configsync@origin/main
 kpt fn render configsync
 kpt live init configsync
 kpt live apply configsync --reconcile-timeout=15m --output=table
@@ -73,7 +73,7 @@ porchctl repo register \
 In case, you are using Gitea then you can use the following steps
 
 ```bash
-kpt pkg get --for-deployment https://github.com/nephio-project/catalog.git/distros/sandbox/repository@origin/v3.0.0 <cluster-name>
+kpt pkg get --for-deployment https://github.com/nephio-project/catalog.git/distros/sandbox/repository@origin/main <cluster-name>
 kpt fn render <cluster-name>
 kpt live init <cluster-name>
 kpt live apply <cluster-name> --reconcile-timeout=15m --output=table
@@ -95,7 +95,7 @@ kpt live apply <cluster-name> --reconcile-timeout=15m --output=table
 Get the *root-sync* *kpt* package and edit it:
 
 ```bash
-kpt pkg get https://github.com/nephio-project/catalog.git/nephio/optional/rootsync@origin/v3.0.0
+kpt pkg get https://github.com/nephio-project/catalog.git/nephio/optional/rootsync@origin/main
 ```
 
 Change *./rootsync/rootsync.yaml* and point *spec.git.repo* to the edge git repository and the  
@@ -146,7 +146,7 @@ config-management-system   mgmt   ddc9676c997696d4a102a5cf2c67d0a0c459ceb3      
 Workload CRDs are required to manage network functions. 
 
 ```bash
-kpt pkg get --for-deployment https://github.com/nephio-project/catalog.git/nephio/core/workload-crds@origin/v3.0.0
+kpt pkg get --for-deployment https://github.com/nephio-project/catalog.git/nephio/core/workload-crds@origin/main
 kpt live init workload-crds
 kpt live apply workload-crds --reconcile-timeout=15m --output=table
 ```

--- a/content/en/docs/guides/install-guides/install-on-single-vm.md
+++ b/content/en/docs/guides/install-guides/install-on-single-vm.md
@@ -26,7 +26,7 @@ In this guide, you will set up Nephio running in a single VM with:
 In addition to the general prerequisites, you will need:
 
 * Access to a Virtual Machine provided by an hypervisor ([VirtualBox](https://www.virtualbox.org/),
-  [Libvirt](https://libvirt.org/)) and running an OS supported by Nephio (Ubuntu 20.04/22.04, Fedora 34) with a minimum
+  [Libvirt](https://libvirt.org/)) and running an OS supported by Nephio (Ubuntu 22.04, Fedora 34) with a minimum
   of 16 vCPUs and 32 GB in RAM.
 * [Kubernetes IN Docker](https://kind.sigs.k8s.io/) (*kind*) installed and set up your workstation.
 
@@ -55,7 +55,7 @@ While you may use other Git providers as well, Gitea is required in the R2 setup
 *nephio-install* directory, run:
 
 ```bash
-kpt pkg get --for-deployment https://github.com/nephio-project/catalog.git/distros/sandbox/gitea@origin/v3.0.0
+kpt pkg get --for-deployment https://github.com/nephio-project/catalog.git/distros/sandbox/gitea@origin/main
 kpt fn render gitea
 kpt live init gitea
 kpt live apply gitea --reconcile-timeout 15m --output=table
@@ -79,7 +79,7 @@ For managing the Kubernetes cluster infrastructure, it is necessary to install
 [cert-manager project](https://cert-manager.io/) to generate certificates.
 
 ```bash
-kpt pkg get --for-deployment https://github.com/nephio-project/catalog.git/distros/sandbox/cert-manager@origin/v3.0.0
+kpt pkg get --for-deployment https://github.com/nephio-project/catalog.git/distros/sandbox/cert-manager@origin/main
 kpt fn render cert-manager
 kpt live init cert-manager
 kpt live apply cert-manager --reconcile-timeout 15m --output=table
@@ -88,7 +88,7 @@ kpt live apply cert-manager --reconcile-timeout 15m --output=table
 Once *cert-manager* is installed, you can proceed with the installation of Cluster API components
 
 ```bash
-kpt pkg get --for-deployment https://github.com/nephio-project/catalog.git/infra/capi/cluster-capi@origin/v3.0.0
+kpt pkg get --for-deployment https://github.com/nephio-project/catalog.git/infra/capi/cluster-capi@origin/main
 kpt fn render cluster-capi
 kpt live init cluster-capi
 kpt live apply cluster-capi --reconcile-timeout 15m --output=table
@@ -98,7 +98,7 @@ Cluster API uses infrastructure providers to provision cloud resources required 
 resources with the Docker provider, it can be installed with the followed package.
 
 ```bash
-kpt pkg get --for-deployment https://github.com/nephio-project/catalog.git/infra/capi/cluster-capi-infrastructure-docker@origin/v3.0.0
+kpt pkg get --for-deployment https://github.com/nephio-project/catalog.git/infra/capi/cluster-capi-infrastructure-docker@origin/main
 kpt fn render cluster-capi-infrastructure-docker
 kpt live init cluster-capi-infrastructure-docker
 kpt live apply cluster-capi-infrastructure-docker --reconcile-timeout 15m --output=table
@@ -109,7 +109,7 @@ machines. These templates define the kubelet arguments, etcd and coreDNS configu
 things.
 
 ```bash
-kpt pkg get --for-deployment https://github.com/nephio-project/catalog.git/infra/capi/cluster-capi-kind-docker-templates@origin/v3.0.0
+kpt pkg get --for-deployment https://github.com/nephio-project/catalog.git/infra/capi/cluster-capi-kind-docker-templates@origin/main
 kpt fn render cluster-capi-kind-docker-templates
 kpt live init cluster-capi-kind-docker-templates
 kpt live apply cluster-capi-kind-docker-templates --reconcile-timeout 15m --output=table
@@ -124,7 +124,7 @@ The management or workload cluster both need *config-sync*, *root-sync* and a cl
 Install *config-sync* using:
 
 ```bash
-kpt pkg get --for-deployment https://github.com/nephio-project/catalog.git/nephio/core/configsync@origin/v3.0.0
+kpt pkg get --for-deployment https://github.com/nephio-project/catalog.git/nephio/core/configsync@origin/main
 kpt fn render configsync
 kpt live init configsync
 kpt live apply configsync --reconcile-timeout=15m --output=table
@@ -137,14 +137,14 @@ For the management cluster, you need to create two repositories named *mgmt* and
 If you are using Gitea then you can use the following steps:
 
 ```bash
-kpt pkg get --for-deployment https://github.com/nephio-project/catalog.git/distros/sandbox/repository@origin/v3.0.0 mgmt
+kpt pkg get --for-deployment https://github.com/nephio-project/catalog.git/distros/sandbox/repository@origin/main mgmt
 kpt fn render mgmt
 kpt live init mgmt
 kpt live apply mgmt --reconcile-timeout=15m --output=table
 ```
 
 ```bash
-kpt pkg get --for-deployment https://github.com/nephio-project/catalog.git/distros/sandbox/repository@origin/v3.0.0 mgmt-staging
+kpt pkg get --for-deployment https://github.com/nephio-project/catalog.git/distros/sandbox/repository@origin/main mgmt-staging
 kpt fn render mgmt-staging
 kpt live init mgmt-staging
 kpt live apply mgmt-staging --reconcile-timeout=15m --output=table
@@ -166,7 +166,7 @@ You would need the name of the config-sync token to provide it to root-sync.
 Get the *root-sync* kpt package and edit it:
 
 ```bash
-kpt pkg get https://github.com/nephio-project/catalog.git/nephio/optional/rootsync@origin/v3.0.0
+kpt pkg get https://github.com/nephio-project/catalog.git/nephio/optional/rootsync@origin/main
 ```
 
 Open *./rootsync/rootsync.yaml* file and update the *spec.git.secretRef.name* to name of config-sync token created in previous step and *metadata.name* to *mgmt*. Also verify that spec.git.repo has correct URL of mgmt git repository

--- a/content/en/docs/guides/install-guides/optional-components.md
+++ b/content/en/docs/guides/install-guides/optional-components.md
@@ -9,7 +9,7 @@ weight: 2
 
 {{% alert title="Note" color="primary" %}}
 
-If you want to use a version other than that of v3.0.0 of Nephio *catalog* repo, then replace the *@origin/v3.0.0*
+If you want to use a version other than that of main of Nephio *catalog* repo, then replace the *@origin/main*
 suffix on the package URLs on the `kpt pkg get` commands below with the tag/branch of the version you wish to use.
 
 While using KPT you can [either pull a branch or a tag](https://kpt.dev/book/03-packages/01-getting-a-package) from a
@@ -17,9 +17,9 @@ git repository. By default, it pulls the tag. In case, you have branch with the 
 
 ```bash
 #pull a branch 
-kpt pkg get --for-deployment <git-repository>@origin/v3.0.0
+kpt pkg get --for-deployment <git-repository>@origin/main
 #pull a tag
-kpt pkg get --for-deployment <git-repository>@v3.0.0
+kpt pkg get --for-deployment <git-repository>@v4.0.0
 ```
 
 {{% /alert %}}

--- a/content/en/docs/guides/install-guides/web-ui/_index.md
+++ b/content/en/docs/guides/install-guides/web-ui/_index.md
@@ -8,7 +8,7 @@ weight: 2
 To install the WebUI, we simply install a different *kpt* package. First, we pull the package locally:
 
 ```bash
-kpt pkg get --for-deployment https://github.com/nephio-project/catalog.git/nephio/optional/webui@origin/v3.0.0
+kpt pkg get --for-deployment https://github.com/nephio-project/catalog.git/nephio/optional/webui@origin/main
 ```
 
 Before we apply it to the cluster, however, we should configure it.


### PR DESCRIPTION
Ubuntu 20.04 is now deprecated, so we should remove it from our support. 

Apart from that, I added a small note that we have not tested on Ubuntu 24 at the moment. The porch and nephio controllers work fine on 24. The issue is mostly with the containerlab router. Probably we need to update its image. 

I also updated the tag from v3.0.0 to `main` because in `main` we should keep the tag `main`

Closing https://github.com/nephio-project/nephio/issues/923 