### PR TITLE
Update dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/nephio-project/docs
 go 1.18
 
 require (
-	github.com/google/docsy v0.10.0 // indirect
-	github.com/google/docsy/dependencies v0.7.2 // indirect
+	github.com/google/docsy v0.12.0 // indirect
+	github.com/google/docsy/dependencies v0.10.0 // indirect
 )

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
   "devDependencies": {
     "autoprefixer": "^10.4.16",
     "postcss": "^8.4.31",
-    "postcss-cli": "^10.1.0"
+    "postcss-cli": "^11.0.1"
   }
 }


### PR DESCRIPTION
This commit updates the following dependencies:

- github.com/google/docsy from v0.10.0 to v0.12.0
- postcss-cli from 10.1.0 to 11.0.1