### PR TITLE
Correct and clean up the Porch CLI user guide

### DIFF
--- a/content/en/docs/porch/user-guides/porchctl-cli-guide.md
+++ b/content/en/docs/porch/user-guides/porchctl-cli-guide.md
@@ -545,7 +545,7 @@ commands above, such as `porchctl rpkg pull`.
 
 ```bash
 # Approve a proposal to publish a package revision
-$ porchctl rpkg approve porch-deployment.new-package-clone.v1 -nporch-demo
+$ porchctl rpkg approve porch-deployment.new-package-clone.v1 -n porch-demo
 porch-deployment.new-package-clone.v1 approved
 
 # Reject a proposal to publish a package revision

--- a/content/en/docs/porch/user-guides/porchctl-cli-guide.md
+++ b/content/en/docs/porch/user-guides/porchctl-cli-guide.md
@@ -242,7 +242,7 @@ The `REVISION` column indicates the revision of the package.
   has a revision of `2` and is the latest revision of the package. The `porch-test.network-function.outerspace` revision of the package has a
   revision of `1`. If the `porch-test.network-function.innerhome3` revision is published, it will be assigned a revision of `3` and will become
   the latest package revision.
-- Packages that are not published (packages with a lifecycle status of `Draft` or `Proposed`) have a revision number of `0`. There can be may revisions
+- Packages that are not published (packages with a lifecycle status of `Draft` or `Proposed`) have a revision number of `0`. There can be many revisions
   of a package with revision `0` as is shown with revisions `porch-test.network-function.innerhome3` and `porch-test.network-function.innerhome4`
   of package `network-function` above.
 - Placeholder packages that point at the tip of a branch or tag have a revision number of `-1`

--- a/content/en/docs/porch/user-guides/porchctl-cli-guide.md
+++ b/content/en/docs/porch/user-guides/porchctl-cli-guide.md
@@ -549,7 +549,7 @@ $ porchctl rpkg approve porch-deployment.new-package-clone.v1 -n porch-demo
 porch-deployment.new-package-clone.v1 approved
 
 # Reject a proposal to publish a package revision
-$ porchctl rpkg reject porch-test.network-function3.innerhome6 -nporch-demo
+$ porchctl rpkg reject porch-test.network-function3.innerhome6 -n porch-demo
 porch-test.network-function3.innerhome6 no longer proposed for approval
 ```
 

--- a/content/en/docs/porch/user-guides/porchctl-cli-guide.md
+++ b/content/en/docs/porch/user-guides/porchctl-cli-guide.md
@@ -522,7 +522,7 @@ porch-test.new-package.my-workspace            new-package                my-wor
 $ porchctl rpkg propose \
   porch-deployment.new-package-clone.v1 \
   porch-test.network-function3.innerhome6 \
-  -nporch-demo
+  -n porch-demo
 
 porch-deployment.new-package-clone.v1 proposed
 porch-test.network-function3.innerhome6 proposed

--- a/content/en/docs/porch/user-guides/porchctl-cli-guide.md
+++ b/content/en/docs/porch/user-guides/porchctl-cli-guide.md
@@ -447,7 +447,7 @@ porch-test.network-function.great-outdoors   network-function   great-outdoors  
 The `porchctl rpkg pull` and `porchctl rpkg push` commands can be used to update the resources (package contents) of a package _draft_:
 
 ```bash
-$ porchctl rpkg pull porch-test.network-function.great-outdoors ./great-outdoors -nporch-demo
+$ porchctl rpkg pull porch-test.network-function.great-outdoors ./great-outdoors -n porch-demo
 
 # Make edits using your favorite YAML editor, for example adding a new resource
 $ cat <<EOF > ./great-outdoors/config-map.yaml

--- a/content/en/docs/porch/user-guides/porchctl-cli-guide.md
+++ b/content/en/docs/porch/user-guides/porchctl-cli-guide.md
@@ -464,7 +464,7 @@ EOF
 $ porchctl rpkg push porch-test.network-function.great-outdoors ./great-outdoors -nporch-demo
 
 # Confirm that the remote package now includes the new ConfigMap resource
-$ porchctl rpkg pull porch-test.network-function.great-outdoors -nporch-demo
+$ porchctl rpkg pull porch-test.network-function.great-outdoors -n porch-demo
 apiVersion: config.kubernetes.io/v1
 kind: ResourceList
 items:

--- a/content/en/docs/porch/user-guides/porchctl-cli-guide.md
+++ b/content/en/docs/porch/user-guides/porchctl-cli-guide.md
@@ -439,7 +439,7 @@ $ porchctl rpkg copy porch-test.network-function.innerhome --workspace=great-out
 porch-test.network-function.great-outdoors created
 
 # Confirm the package revision was created
-$ porchctl rpkg get porch-test.network-function.great-outdoors -nporch-demo
+$ porchctl rpkg get porch-test.network-function.great-outdoors -n porch-demo
 NAME                                         PACKAGE            WORKSPACENAME    REVISION   LATEST   LIFECYCLE   REPOSITORY
 porch-test.network-function.great-outdoors   network-function   great-outdoors   0          false    Draft       porch-test
 ```

--- a/content/en/docs/porch/user-guides/porchctl-cli-guide.md
+++ b/content/en/docs/porch/user-guides/porchctl-cli-guide.md
@@ -486,7 +486,7 @@ Package revision can be deleted using `porchctl rpkg del` command:
 
 ```bash
 # Delete package revision
-$ porchctl rpkg del porch-test.network-function.great-outdoors -nporch-demo
+$ porchctl rpkg del porch-test.network-function.great-outdoors -n porch-demo
 porch-test.network-function.great-outdoors deleted
 ```
 

--- a/content/en/docs/porch/user-guides/porchctl-cli-guide.md
+++ b/content/en/docs/porch/user-guides/porchctl-cli-guide.md
@@ -461,7 +461,7 @@ EOF
 
 # Push the updated contents to the Package Orchestration server, updating the
 # package contents.
-$ porchctl rpkg push porch-test.network-function.great-outdoors ./great-outdoors -nporch-demo
+$ porchctl rpkg push porch-test.network-function.great-outdoors ./great-outdoors -n porch-demo
 
 # Confirm that the remote package now includes the new ConfigMap resource
 $ porchctl rpkg pull porch-test.network-function.great-outdoors -n porch-demo

--- a/content/en/docs/porch/user-guides/porchctl-cli-guide.md
+++ b/content/en/docs/porch/user-guides/porchctl-cli-guide.md
@@ -245,7 +245,7 @@ The `REVISION` column indicates the revision of the package.
 - Packages that are not published (packages with a lifecycle status of `Draft` or `Proposed`) have a revision number of `0`. There can be many revisions
   of a package with revision `0` as is shown with revisions `porch-test.network-function.innerhome3` and `porch-test.network-function.innerhome4`
   of package `network-function` above.
-- Placeholder packages that point at the tip of a branch or tag have a revision number of `-1`
+- Placeholder packages that point at the head of a git branch or tag have a revision number of `-1`
 
 The `LATEST` column indicates whether the package revision is the latest among the revisions of the same package. In the
 output above, `3` is the latest revision of `basens` package and `1` is the latest revision of `empty` package.

--- a/content/en/docs/porch/user-guides/porchctl-cli-guide.md
+++ b/content/en/docs/porch/user-guides/porchctl-cli-guide.md
@@ -225,7 +225,7 @@ The `NAME` column gives the kubernetes name of the package revision resource. Na
 1. The second last part between the second last and last dots is the **package** that the package revision is in.
 1. The last part after the last dot is the **workspace** of the package revision, which uniquely identifies the package revision in the package.
 
-From the listing above the package revision with name `test-blueprints.basens.v3` is in a repository called `test-blueprints`. It is in the root of that
+From the listing above, the package revision with the name `test-blueprints.basens.v3`, is in a repository called `test-blueprints`. It is in the root of that
 repository because there are no **pathnode** entries in its name. It is in a package called `basens` and its workspace name is `v3`.
 
 The package revision with the name `porch-test.basedir.subdir.subsubdir.edge-function.inadir` is in the repo `porch-test`. It has a path of

--- a/content/en/docs/porch/user-guides/porchctl-cli-guide.md
+++ b/content/en/docs/porch/user-guides/porchctl-cli-guide.md
@@ -35,20 +35,20 @@ The commands for administering repositories are:
 
 The commands for administering package revisions are:
 
-| Command                        | Description                                                                             |
-| ------------------------------ | --------------------------------------------------------------------------------------- |
-| `porchctl rpkg approve`        | Approve a proposal to publish a package revision.                                       |
-| `porchctl rpkg clone`          | Create a clone of an existing package revision.                                         |
-| `porchctl rpkg copy`           | Create a new package revision from an existing one.                                     |
-| `porchctl rpkg del`            | Delete a package revision.                                                              |
-| `porchctl rpkg get`            | List package revisions in registered repositories.                                      |
-| `porchctl rpkg init`           | Initializes a new package in a repository.                                              |
-| `porchctl rpkg propose`        | Propose that a package revision should be published.                                    |
-| `porchctl rpkg propose-delete` | Propose deletion of a published package revision.                                       |
-| `porchctl rpkg pull`           | Pull the content of the package revision.                                               |
-| `porchctl rpkg push`           | Push resources to a package revision.                                                   |
-| `porchctl rpkg reject`         | Reject a proposal to publish or delete a package revision.                              |
-| `porchctl rpkg update`         | Update a downstream package revision to a more recent revision of its upstream package. |
+| Command                        | Description                                                                                      |
+| ------------------------------ | ------------------------------------------------------------------------------------------------ |
+| `porchctl rpkg approve`        | Approve a proposal to publish a package revision.                                                |
+| `porchctl rpkg clone`          | Create a clone of an existing package revision.                                                  |
+| `porchctl rpkg copy`           | Create a new package revision from an existing one.                                              |
+| `porchctl rpkg del`            | Delete a package revision.                                                                       |
+| `porchctl rpkg get`            | List package revisions in registered repositories.                                               |
+| `porchctl rpkg init`           | Initializes a new package revision in a repository.                                              |
+| `porchctl rpkg propose`        | Propose that a package revision should be published.                                             |
+| `porchctl rpkg propose-delete` | Propose deletion of a published package revision.                                                |
+| `porchctl rpkg pull`           | Pull the content of the package revision.                                                        |
+| `porchctl rpkg push`           | Push resources to a package revision.                                                            |
+| `porchctl rpkg reject`         | Reject a proposal to publish or delete a package revision.                                       |
+| `porchctl rpkg update`         | Update a downstream package revision to a more recent revision of its upstream package revision. |
 
 ## Using the porchctl CLI
 
@@ -173,10 +173,10 @@ $ porchctl repo unregister test-blueprints --namespace default
 
 ## Package Discovery And Introspection
 
-The `porchctl rpkg` command group contains commands for interacting with packages managed by the Package Orchestration
+The `porchctl rpkg` command group contains commands for interacting with package revisions managed by the Package Orchestration
 service. the `r` prefix used in the command group name stands for 'remote'.
 
-The `porchctl rpkg get` command list the packages in registered repositories:
+The `porchctl rpkg get` command list the package revisions in registered repositories:
 
 ```bash
 $ porchctl rpkg get -A
@@ -255,23 +255,23 @@ the packages `basedir/subdir/subsubdir/edge-function` and `basedir/subdir/subsub
 `basedir/subdir/subsubdir/network-function` and `network-function` packages are different packages because they are in different directories.
 
 The `REVISION` column indicates the revision of the package.
-- Revisions of `1` or greater indicate released packages. When a package revision is `Published` it is assigned the next
+- Revisions of `1` or greater indicate released package revisions. When a package revision is `Published` it is assigned the next
   available revision number, starting at `1`. In the listing above, the `porch-test.network-function.innerhome` revision of package `network-function`
   has a revision of `2` and is the latest revision of the package. The `porch-test.network-function.outerspace` revision of the package has a
   revision of `1`. If the `porch-test.network-function.innerhome3` revision is published, it will be assigned a revision of `3` and will become
   the latest package revision.
-- Packages that are not published (packages with a lifecycle status of `Draft` or `Proposed`) have a revision number of `0`. There can be many revisions
-  of a package with revision `0` as is shown with revisions `porch-test.network-function.innerhome3` and `porch-test.network-function.innerhome4`
+- Package revisions that are not published (package revisions with a lifecycle status of `Draft` or `Proposed`) have a revision number of `0`. There can be many
+  revisions of a package with revision `0` as is shown with revisions `porch-test.network-function.innerhome3` and `porch-test.network-function.innerhome4`
   of package `network-function` above.
-- Placeholder packages that point at the head of a git branch or tag have a revision number of `-1`
+- Placeholder package revisions that point at the head of a git branch or tag have a revision number of `-1`
 
 The `LATEST` column indicates whether the package revision is the latest among the revisions of the same package. In the
 output above, `3` is the latest revision of `basens` package and `1` is the latest revision of `empty` package.
 
 The `LIFECYCLE` column indicates the lifecycle stage of the package revision, one of: `Draft`, `Proposed`, `Published` or `DeletionProposed`.
 
-The `WORKSPACENAME` column indicates the workspace name of the package. The workspace name is selected by a user when a draft
-revision is created. The workspace name must be unique among package revisions in the same package. A user is free to
+The `WORKSPACENAME` column indicates the workspace name of a package revision. The workspace name is selected by a user when a draft
+package revision is created. The workspace name must be unique among package revisions in the same package. A user is free to
 select any workspace name that complies with the constraints on DNS Subdomain Names specified in
 [kubernetes rules for naming objects and IDs](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/).
 
@@ -342,7 +342,7 @@ spec:
 ...
 ```
 
-The `porchctl rpkg pull` command can be used to read the package resources.
+The `porchctl rpkg pull` command can be used to read the package revision resources.
 
 The command can be used to print the package revision resources as `ResourceList` to `stdout`, which enables
 [chaining](https://kpt.dev/book/04-using-functions/02-imperative-function-execution?id=chaining-functions-using-the-unix-pipe)
@@ -361,7 +361,7 @@ items:
 ...
 ```
 
-Or, the package contents can be saved on local disk for direct introspection or editing:
+Or, the package revision contents can be saved on local disk for direct introspection or editing:
 
 ```bash
 $ porchctl rpkg pull -n porch-demo porch-test.network-function.innerhome ./innerhome
@@ -380,13 +380,13 @@ $ find innerhome
 Several commands in the `porchctl rpkg` group support package authoring:
 
 * `init` - Initializes a new package revision in the target repository.
-* `clone` - Creates a clone of a source package in the target repository.
+* `clone` - Creates a clone of a source package revision in the target repository.
 * `copy` - Creates a new package revision from an existing one.
-* `push` - Pushes package resources into a remote package.
-* `del` - Deletes one or more packages in registered repositories.
+* `push` - Pushes package revision resources into a remote package.
+* `del` - Deletes one or more package revisions in registered repositories.
 
 The `porchctl rpkg init` command can be used to initialize a new package revision. Porch server will create and
-initialize a new package (as a draft) and save it in the specified repository.
+initialize a new package revision (as a draft) and save it in the specified repository.
 
 ```bash
 $ porchctl rpkg init new-package --repository=porch-test --workspace=my-workspace -n porch-demo
@@ -397,19 +397,19 @@ NAME                                  PACKAGE       WORKSPACENAME   REVISION   L
 porch-test.new-package.my-workspace   new-package   my-workspace    0          false    Draft       porch-test
 ```
 
-The new package is created in the `Draft` lifecycle stage. This is true also for all commands that create new package
+The new package revision is created in the `Draft` lifecycle stage. This is true also for all commands that create new package
 revision (`init`, `clone` and `copy`).
 
 Additional flags supported by the `porchctl rpkg init` command are:
 
-* `--repository` - Repository in which the package will be created.
-* `--workspace` - Workspace of the new package.
-* `--description` -  Short description of the package.
-* `--keywords` - List of keywords for the package.
-* `--site` - Link to page with information about the package.
+* `--repository` - Repository in which the package revision will be created.
+* `--workspace` - Workspace of the new package revision.
+* `--description` -  Short description of the package revision.
+* `--keywords` - List of keywords for the package revision.
+* `--site` - Link to page with information about the package revision.
 
 
-Use `porchctl rpkg clone` command to create a _downstream_ package by cloning an _upstream_ package:
+Use `porchctl rpkg clone` command to create a _downstream_ package revision by cloning an _upstream_ package revision:
 
 ```bash
 $ porchctl rpkg clone porch-test.new-package.my-workspace new-package-clone --repository=porch-deployment -n porch-demo
@@ -421,7 +421,7 @@ NAME                                    PACKAGE             WORKSPACENAME   REVI
 porch-deployment.new-package-clone.v1   new-package-clone   v1              0          false    Draft       porch-deployment
 ```
 
-`porchctl rpkg clone` can also be used to clone packages that are in repositories not registered with Porch, for
+`porchctl rpkg clone` can also be used to clone package revisions that are in repositories not registered with Porch, for
 example:
 
 ```bash
@@ -442,13 +442,13 @@ porch-deployment.cloned-pkg-example-ue-bp.v1   cloned-pkg-example-ue-bp   v1    
 The flags supported by the `porchctl rpkg clone` command are:
 
 * `--directory` - Directory within the upstream repository where the upstream
-  package is located.
-* `--ref` - Ref in the upstream repository where the upstream package is
+  package revision is located.
+* `--ref` - Ref in the upstream repository where the upstream package revision is
   located. This can be a branch, tag, or SHA.
-* `--repository` - Repository to which package will be cloned (downstream
+* `--repository` - Repository to which package revision will be cloned (downstream
   repository).
-* `--workspace` - Workspace to assign to the downstream package.
-* `--strategy` - Update strategy that should be used when updating this package;
+* `--workspace` - Workspace to assign to the downstream package revision.
+* `--strategy` - Update strategy that should be used when updating this package revision;
   one of: `resource-merge`, `fast-forward`, `force-delete-replace`, `copy-merge`.
 
 
@@ -465,7 +465,7 @@ NAME                                         PACKAGE            WORKSPACENAME   
 porch-test.network-function.great-outdoors   network-function   great-outdoors   0          false    Draft       porch-test
 ```
 
-The `porchctl rpkg pull` and `porchctl rpkg push` commands can be used to update the resources (package contents) of a package _draft_:
+The `porchctl rpkg pull` and `porchctl rpkg push` commands can be used to update the resources (package revision contents) of a package _draft_:
 
 ```bash
 $ porchctl rpkg pull porch-test.network-function.great-outdoors ./great-outdoors -n porch-demo
@@ -481,10 +481,10 @@ data:
 EOF
 
 # Push the updated contents to the Package Orchestration server, updating the
-# package contents.
+# package revision contents.
 $ porchctl rpkg push porch-test.network-function.great-outdoors ./great-outdoors -n porch-demo
 
-# Confirm that the remote package now includes the new ConfigMap resource
+# Confirm that the remote package revision now includes the new ConfigMap resource
 $ porchctl rpkg pull porch-test.network-function.great-outdoors -n porch-demo
 apiVersion: config.kubernetes.io/v1
 kind: ResourceList
@@ -513,17 +513,17 @@ porch-test.network-function.great-outdoors deleted
 
 ## Package Lifecycle and Approval Flow
 
-Authoring is performed on the package revisions in the _Draft_ lifecycle stage. Before a package can be deployed, copied or
-cloned, it must be _Published_. The approval flow is the process by which the package is advanced from _Draft_ state
+Authoring is performed on the package revisions in the _Draft_ lifecycle stage. Before a package revision can be deployed, copied or
+cloned, it must be _Published_. The approval flow is the process by which the package revision is advanced from _Draft_ state
 through _Proposed_ state and finally to _Published_ lifecycle stage.
 
-The commands used to manage package lifecycle stages include:
+The commands used to manage package revision lifecycle stages include:
 
 * `propose` - Proposes to finalize a package revision draft
 * `approve` - Approves a proposal to finalize a package revision.
 * `reject`  - Rejects a proposal to finalize a package revision
 
-In the [Authoring Packages](#authoring-packages) section above we created several _draft_ packages and in this section
+In the [Authoring Packages](#authoring-packages) section above we created several _draft_ package revisions and in this section
 we will create proposals for publishing some of them.
 
 ```bash
@@ -561,7 +561,7 @@ porch-test.new-package.my-workspace            new-package                my-wor
 ```
 
 At this point, a person in _platform administrator_ role, or even an automated process, will review and either approve
-or reject the proposals. To aid with the decision, the platform administrator may inspect the package contents using the
+or reject the proposals. To aid with the decision, the platform administrator may inspect the package revision contents using the
 commands above, such as `porchctl rpkg pull`.
 
 ```bash
@@ -589,7 +589,7 @@ porch-test.network-function3.innerhome6        network-function3          innerh
 porch-test.new-package.my-workspace            new-package                my-workspace    0          false    Draft       porch-test
 ```
 
-Observe that the rejected proposal returned the package revision back to _Draft_ lifecycle stage. The package whose
+Observe that the rejected proposal returned the package revision back to _Draft_ lifecycle stage. The package revision whose
 proposal was approved is now in _Published_ state.
 
 An approved pacakge revision cannot be directly deleted, it must first be proposed for deletion.

--- a/content/en/docs/porch/user-guides/porchctl-cli-guide.md
+++ b/content/en/docs/porch/user-guides/porchctl-cli-guide.md
@@ -435,7 +435,7 @@ The `porchctl rpkg copy` command can be used to create a new revision of an exis
 modifying an already published package revision.
 
 ```bash
-$ porchctl rpkg copy porch-test.network-function.innerhome --workspace=great-outdoors -nporch-demo
+$ porchctl rpkg copy porch-test.network-function.innerhome --workspace=great-outdoors -n porch-demo
 porch-test.network-function.great-outdoors created
 
 # Confirm the package revision was created

--- a/content/en/docs/porch/user-guides/porchctl-cli-guide.md
+++ b/content/en/docs/porch/user-guides/porchctl-cli-guide.md
@@ -258,7 +258,7 @@ revision is created. The workspace name must be unique among package revisions i
 {{% alert title="Scope of WORKSPACENAME" color="primary" %}}
 The scope of a workspace name is restricted to its package and it is merely a string that identifies a package revision within a package. A user is free to
 pick any workspace name that complies with [kubernetes rules for naming objects and IDs](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/).
-The workspace name `V1` on the `empty` package has no relation whatever to the workspace name `V1` on the `basens` package on the listing above,
+The workspace name `V1` on the `empty` package has no relation to the workspace name `V1` on the `basens` package listed above.
 A user has simply decided to use the same workspace name on two separate packages.
 {{% /alert %}}
 

--- a/content/en/docs/porch/user-guides/porchctl-cli-guide.md
+++ b/content/en/docs/porch/user-guides/porchctl-cli-guide.md
@@ -238,7 +238,7 @@ the packages `basedir/subdir/subsubdir/edge-function` and `basedir/subdir/subsub
 
 The `REVISION` column indicates the revision of the package.
 - Revisions of `1` or greater indicate released packages. When a package is `Published`. When a package is published, it is assigned the next
-  available revision number, startting at `1`. In the isting above the `porch-test.network-function.innerhome` revision of package `network-function`
+  available revision number, starting at `1`. In the listing above, the `porch-test.network-function.innerhome` revision of package `network-function`
   has a revision of `2` and is the latest revision of the package. The `porch-test.network-function.outerspace` revision of the package has a
   revision of `1`. If the `porch-test.network-function.innerhome3` revision is published, it will be assigned a revision of `3` and will become
   the latest package revision.

--- a/content/en/docs/porch/user-guides/porchctl-cli-guide.md
+++ b/content/en/docs/porch/user-guides/porchctl-cli-guide.md
@@ -272,7 +272,7 @@ of this directory. Porch then examines all branches and tags that have reference
 2. If 1. fails, and if the reference is of the form `<package>.v1`, set the workspace name to `v1` and the revision to `1` as is the case for the
    `test-blueprints.basens.v1` package revision in the listing above.
 3. If 2. fails, set the workspace name to the branch or tag name, and the revision to `-1`, as is the case for the `infra.infra.gcp.nephio-blueprint-repo.v3.0.0`
-   package revision in the listing above, the workspace name is set to the branch name `v3.0.0` and the revision is set to `-1`.
+   package revision in the listing above. The workspace name is set to the branch name `v3.0.0`, and the revision is set to `-1`.
 {{% /alert %}}
 
 ## Package Revision Filtering

--- a/content/en/docs/porch/user-guides/porchctl-cli-guide.md
+++ b/content/en/docs/porch/user-guides/porchctl-cli-guide.md
@@ -269,7 +269,7 @@ of this directory. Porch then examines all branches and tags that have reference
 1. Look for a commit message of the form `kpt:{"package":"network-function","workspaceName":"outerspace","revision":"1"}` at the tip of the branch/tag and
    set the workspace name and revision from the commit message, `outerspace` and `1` respectively in the case of the `porch-test.network-function.outerspace`
    package revision in the listing above.
-2. If 1. fails, if the reference is of the form `<package>.v1`, set the workspace name to `v1` and the revision to `1` as in the case of the
+2. If 1. fails, and if the reference is of the form `<package>.v1`, set the workspace name to `v1` and the revision to `1` as is the case for the
    `test-blueprints.basens.v1` package revision in the listing above.
 3. if 2. fails, set the workspace name to the branch or tag name and the revision to `-1`, so in the case of the `infra.infra.gcp.nephio-blueprint-repo.v3.0.0`
    package revision in the listing above, the workspace name is set to the branch name `v3.0.0` and the revision is set to `-1`.

--- a/content/en/docs/porch/user-guides/porchctl-cli-guide.md
+++ b/content/en/docs/porch/user-guides/porchctl-cli-guide.md
@@ -369,7 +369,7 @@ The `porchctl rpkg init` command can be used to initialize a new package revisio
 initialize a new package (as a draft) and save it in the specified repository.
 
 ```bash
-$ porchctl rpkg init new-package --repository=porch-test --workspace=my-workspace -nporch-demo
+$ porchctl rpkg init new-package --repository=porch-test --workspace=my-workspace -n porch-demo
 porch-test.new-package.my-workspace created
 
 $ porchctl rpkg get -n porch-demo porch-test.new-package.my-workspace

--- a/content/en/docs/porch/user-guides/porchctl-cli-guide.md
+++ b/content/en/docs/porch/user-guides/porchctl-cli-guide.md
@@ -259,7 +259,7 @@ revision is created. The workspace name must be unique among package revisions i
 The scope of a workspace name is restricted to its package and it is merely a string that identifies a package revision within a package. A user is free to
 pick any workspace name that complies with [kubernetes rules for naming objects and IDs](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/).
 The workspace name `V1` on the `empty` package has no relation whatever to the workspace name `V1` on the `basens` package on the listing above,
-a user has decided to use the same workspace name on two separate packages.
+A user has simply decided to use the same workspace name on two separate packages.
 {{% /alert %}}
 
 {{% alert title="Setting WORKSPACENAME and REVISION from repositories" color="primary" %}}

--- a/content/en/docs/porch/user-guides/porchctl-cli-guide.md
+++ b/content/en/docs/porch/user-guides/porchctl-cli-guide.md
@@ -233,7 +233,7 @@ The package revision with the name `porch-test.basedir.subdir.subsubdir.edge-fun
 
 The `PACKAGE` column contains the package name of a pacakge revision. Of course, all package revisions in a package have the same package name. The
 package name includes the path to the directory containing the package if the package is not in the root directory of the repo. For example, in the listing above
-the packages `basedir/subdir/subsubdir/edge-function` and `basedir/subdir/subsubdir/network-function` are in the directory `basedir/subdir/subsubdir`. THe
+the packages `basedir/subdir/subsubdir/edge-function` and `basedir/subdir/subsubdir/network-function` are in the directory `basedir/subdir/subsubdir`. The
 `basedir/subdir/subsubdir/network-function` and `network-function` packages are different packages because they are in different directories.
 
 The `REVISION` column indicates the revision of the package.

--- a/content/en/docs/porch/user-guides/porchctl-cli-guide.md
+++ b/content/en/docs/porch/user-guides/porchctl-cli-guide.md
@@ -271,7 +271,7 @@ of this directory. Porch then examines all branches and tags that have reference
    package revision in the listing above.
 2. If 1. fails, and if the reference is of the form `<package>.v1`, set the workspace name to `v1` and the revision to `1` as is the case for the
    `test-blueprints.basens.v1` package revision in the listing above.
-3. if 2. fails, set the workspace name to the branch or tag name and the revision to `-1`, so in the case of the `infra.infra.gcp.nephio-blueprint-repo.v3.0.0`
+3. If 2. fails, set the workspace name to the branch or tag name, and the revision to `-1`, as is the case for the `infra.infra.gcp.nephio-blueprint-repo.v3.0.0`
    package revision in the listing above, the workspace name is set to the branch name `v3.0.0` and the revision is set to `-1`.
 {{% /alert %}}
 

--- a/content/en/docs/porch/user-guides/porchctl-cli-guide.md
+++ b/content/en/docs/porch/user-guides/porchctl-cli-guide.md
@@ -396,7 +396,7 @@ $ porchctl rpkg clone porch-test.new-package.my-workspace new-package-clone --re
 porch-deployment.new-package-clone.v1 created
 
 # Confirm the package revision was created
-porchctl rpkg get porch-deployment.new-package-clone.v1 -nporch-demo
+porchctl rpkg get porch-deployment.new-package-clone.v1 -n porch-demo
 NAME                                    PACKAGE             WORKSPACENAME   REVISION   LATEST   LIFECYCLE   REPOSITORY
 porch-deployment.new-package-clone.v1   new-package-clone   v1              0          false    Draft       porch-deployment
 ```

--- a/content/en/docs/porch/user-guides/porchctl-cli-guide.md
+++ b/content/en/docs/porch/user-guides/porchctl-cli-guide.md
@@ -221,7 +221,7 @@ The `NAME` column gives the kubernetes name of the package revision resource. Na
 **repository.([pathnode.]*)package.workspace**
 
 1. The first part up to the first dot is the **repository** that the package revision is in.
-1. The scond (optional) part is zero or more **pathnode** nodes, identifying the path of the package.
+1. The second (optional) part is zero or more **pathnode** nodes, identifying the path of the package.
 1. The second last part between the second last and last dots is the **package** that the package revision is in.
 1. The last part after the last dot is the **workspace** of the package revision, which uniquely identifies the package revision in the package.
 

--- a/content/en/docs/porch/user-guides/porchctl-cli-guide.md
+++ b/content/en/docs/porch/user-guides/porchctl-cli-guide.md
@@ -392,7 +392,7 @@ Additional flags supported by the `porchctl rpkg init` command are:
 Use `porchctl rpkg clone` command to create a _downstream_ package by cloning an _upstream_ package:
 
 ```bash
-$ porchctl rpkg clone porch-test.new-package.my-workspace new-package-clone --repository=porch-deployment -nporch-demo
+$ porchctl rpkg clone porch-test.new-package.my-workspace new-package-clone --repository=porch-deployment -n porch-demo
 porch-deployment.new-package-clone.v1 created
 
 # Confirm the package revision was created


### PR DESCRIPTION
The Porch CLI user guide is updated:
- Uses the new style package revision names
- Adds the `copy-merge` merge strategy
- Adds a description ondeleting Published PRs (propose-delete/delete)
- Provides better descritions of Porch behaviour/usage of Names, workspaces, and revisions.